### PR TITLE
ci: add unity tests and builds

### DIFF
--- a/.github/workflows/unity.yml
+++ b/.github/workflows/unity.yml
@@ -19,6 +19,8 @@ jobs:
         targetPlatform:
           - StandaloneLinux64
           - iOS
+          - Android
+          - WebGL
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/unity.yml
+++ b/.github/workflows/unity.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   buildAndTestForLinuxBasedPlatforms:
-    name: Build & Test for ${{ matrix.targetPlatform }}
+    name: Build & Test for ${{ matrix.targetPlatform }} on ${{ matrix.unityVersion }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -54,8 +54,8 @@ jobs:
           path: build
 
   buildForWindowsBasedPlatforms:
-    name: Build for ${{ matrix.targetPlatform }}
-    runs-on: windows-latest
+    name: Build for ${{ matrix.targetPlatform }} on ${{ matrix.unityVersion }}
+    runs-on: windows-2019
     strategy:
       fail-fast: false
       matrix:
@@ -93,7 +93,7 @@ jobs:
           path: build
 
   buildForMacOSBasedPlatforms:
-    name: Build for ${{ matrix.targetPlatform }}
+    name: Build for ${{ matrix.targetPlatform }} on ${{ matrix.unityVersion }}
     runs-on: macos-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/unity.yml
+++ b/.github/workflows/unity.yml
@@ -1,10 +1,10 @@
-﻿name: Unity Actions
+﻿name: Unity
 
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
   buildAndTestForLinuxBasedPlatforms:
-    name: Build for ${{ matrix.targetPlatform }}
+    name: Build & Test for ${{ matrix.targetPlatform }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -85,19 +85,6 @@ jobs:
             Library-${{ matrix.projectPath }}-${{ matrix.targetPlatform }}-
             Library-${{ matrix.projectPath }}-
             Library-
-      - uses: game-ci/unity-test-runner@v2
-        id: testRunner
-        env:
-          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
-        with:
-          projectPath: ${{ matrix.projectPath }}
-          unityVersion: ${{ matrix.unityVersion }}
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: Test results (all modes)
-          path: ${{ steps.testRunner.outputs.artifactsPath }}
       - uses: game-ci/unity-builder@v2
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
@@ -140,20 +127,6 @@ jobs:
             Library-${{ matrix.projectPath }}-${{ matrix.targetPlatform }}-
             Library-${{ matrix.projectPath }}-
             Library-
-            
-      - uses: game-ci/unity-test-runner@v2
-        id: testRunner
-        env:
-          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
-        with:
-          projectPath: ${{ matrix.projectPath }}
-          unityVersion: ${{ matrix.unityVersion }}
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: Test results (all modes)
-          path: ${{ steps.testRunner.outputs.artifactsPath }}
 
       - uses: game-ci/unity-builder@v2
         env:

--- a/.github/workflows/unity.yml
+++ b/.github/workflows/unity.yml
@@ -1,0 +1,171 @@
+﻿name: Unity Actions
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  buildAndTestForLinuxBasedPlatforms:
+    name: Build for ${{ matrix.targetPlatform }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        projectPath:
+          - uicomponents
+        unityVersion:
+          - 2019.4.38f1
+          - 2020.3.33f1
+          - 2021.3.1f1
+        targetPlatform:
+          - StandaloneLinux64
+          - iOS
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/cache@v3
+        with:
+          path: ${{ matrix.projectPath }}/Library
+          key: Library-${{ matrix.projectPath }}-${{ matrix.targetPlatform }}-${{ hashFiles(matrix.projectPath) }}
+          restore-keys: |
+            Library-${{ matrix.projectPath }}-${{ matrix.targetPlatform }}-
+            Library-${{ matrix.projectPath }}-
+            Library-
+      - uses: game-ci/unity-test-runner@v2
+        id: testRunner
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+        with:
+          projectPath: ${{ matrix.projectPath }}
+          unityVersion: ${{ matrix.unityVersion }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: Test results (all modes)
+          path: ${{ steps.testRunner.outputs.artifactsPath }}
+      - uses: game-ci/unity-builder@v2
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          projectPath: ${{ matrix.projectPath }}
+          unityVersion: ${{ matrix.unityVersion }}
+          targetPlatform: ${{ matrix.targetPlatform }}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Build
+          path: build
+
+  buildForWindowsBasedPlatforms:
+    name: Build for ${{ matrix.targetPlatform }}
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        projectPath:
+          - uicomponents
+        unityVersion:
+          - 2019.4.38f1
+          - 2020.3.33f1
+          - 2021.3.1f1
+        targetPlatform:
+          - StandaloneWindows
+          - StandaloneWindows64
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/cache@v3
+        with:
+          path: ${{ matrix.projectPath }}/Library
+          key: Library-${{ matrix.projectPath }}-${{ matrix.targetPlatform }}-${{ hashFiles(matrix.projectPath) }}
+          restore-keys: |
+            Library-${{ matrix.projectPath }}-${{ matrix.targetPlatform }}-
+            Library-${{ matrix.projectPath }}-
+            Library-
+      - uses: game-ci/unity-test-runner@v2
+        id: testRunner
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+        with:
+          projectPath: ${{ matrix.projectPath }}
+          unityVersion: ${{ matrix.unityVersion }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: Test results (all modes)
+          path: ${{ steps.testRunner.outputs.artifactsPath }}
+      - uses: game-ci/unity-builder@v2
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          projectPath: ${{ matrix.projectPath }}
+          unityVersion: ${{ matrix.unityVersion }}
+          targetPlatform: ${{ matrix.targetPlatform }}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Build
+          path: build
+
+  buildForMacOSBasedPlatforms:
+    name: Build for ${{ matrix.targetPlatform }}
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        projectPath:
+          - uicomponents
+        unityVersion:
+          - 2019.4.38f1
+          - 2020.3.33f1
+          - 2021.3.1f1
+        targetPlatform:
+          - StandaloneOSX
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/cache@v3
+        with:
+          path: ${{ matrix.projectPath }}/Library
+          key: Library-${{ matrix.projectPath }}-${{ matrix.targetPlatform }}-${{ hashFiles(matrix.projectPath) }}
+          restore-keys: |
+            Library-${{ matrix.projectPath }}-${{ matrix.targetPlatform }}-
+            Library-${{ matrix.projectPath }}-
+            Library-
+            
+      - uses: game-ci/unity-test-runner@v2
+        id: testRunner
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+        with:
+          projectPath: ${{ matrix.projectPath }}
+          unityVersion: ${{ matrix.unityVersion }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: Test results (all modes)
+          path: ${{ steps.testRunner.outputs.artifactsPath }}
+
+      - uses: game-ci/unity-builder@v2
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          projectPath: ${{ matrix.projectPath }}
+          unityVersion: ${{ matrix.unityVersion }}
+          targetPlatform: ${{ matrix.targetPlatform }}
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Build
+          path: build

--- a/.github/workflows/unity.yml
+++ b/.github/workflows/unity.yml
@@ -9,8 +9,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        projectPath:
-          - uicomponents
         unityVersion:
           - 2019.4.38f1
           - 2020.3.33f1
@@ -35,7 +33,6 @@ jobs:
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
         with:
-          projectPath: ${{ matrix.projectPath }}
           unityVersion: ${{ matrix.unityVersion }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/upload-artifact@v3
@@ -49,7 +46,6 @@ jobs:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
         with:
-          projectPath: ${{ matrix.projectPath }}
           unityVersion: ${{ matrix.unityVersion }}
           targetPlatform: ${{ matrix.targetPlatform }}
       - uses: actions/upload-artifact@v3
@@ -63,8 +59,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        projectPath:
-          - uicomponents
         unityVersion:
           - 2019.4.38f1
           - 2020.3.33f1
@@ -91,7 +85,6 @@ jobs:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
         with:
-          projectPath: ${{ matrix.projectPath }}
           unityVersion: ${{ matrix.unityVersion }}
           targetPlatform: ${{ matrix.targetPlatform }}
       - uses: actions/upload-artifact@v3
@@ -105,8 +98,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        projectPath:
-          - uicomponents
         unityVersion:
           - 2019.4.38f1
           - 2020.3.33f1
@@ -134,7 +125,6 @@ jobs:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
         with:
-          projectPath: ${{ matrix.projectPath }}
           unityVersion: ${{ matrix.unityVersion }}
           targetPlatform: ${{ matrix.targetPlatform }}
 

--- a/.github/workflows/unity.yml
+++ b/.github/workflows/unity.yml
@@ -2,6 +2,9 @@
 
 on: [push, pull_request, workflow_dispatch]
 
+env:
+  PROJECT_UNITY_VERSION: 2020.3.33f1
+
 jobs:
   buildAndTestForLinuxBasedPlatforms:
     name: Build & Test for ${{ matrix.targetPlatform }} on ${{ matrix.unityVersion }}
@@ -40,6 +43,12 @@ jobs:
         with:
           name: Test results (all modes)
           path: ${{ steps.testRunner.outputs.artifactsPath }}
+      - name: Commit upgrade changes
+        if: ${{ matrix.unityVersion != env.PROJECT_UNITY_VERSION }}
+        run: |
+          git config --global user.name 'github-bot'
+          git config --global user.email 'github-bot@users.noreply.github.com'
+          git commit -am "chore(ci): switch to different unity version"
       - uses: game-ci/unity-builder@v2
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}

--- a/.github/workflows/unity.yml
+++ b/.github/workflows/unity.yml
@@ -48,7 +48,8 @@ jobs:
         run: |
           git config --global user.name 'github-bot'
           git config --global user.email 'github-bot@users.noreply.github.com'
-          git commit -am "chore(ci): switch to different unity version"
+          git add -A
+          git commit -m "chore(ci): switch to different unity version"
       - uses: game-ci/unity-builder@v2
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ crashlytics-build.properties
 
 /CodeCoverage/
 .idea/
+/artifacts/

--- a/Assets/Examples/Counter/ICounterService.cs
+++ b/Assets/Examples/Counter/ICounterService.cs
@@ -2,7 +2,7 @@
 {
     public interface ICounterService
     {
-        public void IncrementCount();
-        public int GetCount();   
+        void IncrementCount();
+        int GetCount();   
     }   
 }

--- a/Assets/UIComponents/Core/IAssetResolver.cs
+++ b/Assets/UIComponents/Core/IAssetResolver.cs
@@ -12,13 +12,13 @@
         /// <param name="assetPath">Asset path</param>
         /// <typeparam name="T">Asset type</typeparam>
         /// <returns>Asset object</returns>
-        public T LoadAsset<T>(string assetPath) where T : UnityEngine.Object;
+        T LoadAsset<T>(string assetPath) where T : UnityEngine.Object;
 
         /// <summary>
         /// Returns whether the asset exists.
         /// </summary>
         /// <param name="assetPath">Asset path</param>
         /// <returns>Whether the asset exists</returns>
-        public bool AssetExists(string assetPath);
+        bool AssetExists(string assetPath);
     }
 }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "com.unity.collab-proxy": "1.15.15",
     "com.unity.ide.rider": "2.0.7",
     "com.unity.ide.visualstudio": "2.0.14",
     "com.unity.ide.vscode": "1.2.5",

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -5,7 +5,6 @@
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.test-framework": "1.1.31",
     "com.unity.testtools.codecoverage": "1.1.1",
-    "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.4.8",
     "com.unity.ugui": "1.0.0",
     "com.unity.modules.ai": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -60,15 +60,6 @@
       },
       "url": "https://packages.unity.com"
     },
-    "com.unity.textmeshpro": {
-      "version": "3.0.6",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.ugui": "1.0.0"
-      },
-      "url": "https://packages.unity.com"
-    },
     "com.unity.timeline": {
       "version": "1.4.8",
       "depth": 0,

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,14 +1,5 @@
 {
   "dependencies": {
-    "com.unity.collab-proxy": {
-      "version": "1.15.15",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.services.core": "1.0.1"
-      },
-      "url": "https://packages.unity.com"
-    },
     "com.unity.ext.nunit": {
       "version": "1.0.6",
       "depth": 1,
@@ -39,15 +30,6 @@
       "depth": 0,
       "source": "registry",
       "dependencies": {},
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.services.core": {
-      "version": "1.0.1",
-      "depth": 1,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.modules.unitywebrequest": "1.0.0"
-      },
       "url": "https://packages.unity.com"
     },
     "com.unity.settings-manager": {

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -4,5 +4,8 @@
 EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
-  m_Scenes: []
+  m_Scenes:
+  - enabled: 1
+    path: Assets/Scenes/SampleScene.unity
+    guid: 9fc0d4010bbf28b4594072e72b8655ab
   m_configObjects: {}


### PR DESCRIPTION
Adds automatic tests and builds for

- Linux
- iOS
- Android
- WebGL

and automated builds for
- Windows 32-bit
- Windows 64-bit
- MacOS

on Unity versions
- 2019.4.38f1
- 2020.3.33f1
- 2021.3.1f1.

Fixes a couple of issues that caused compilation errors on 2019, making the package fully compatible with that version.

TextMeshPro and Version Control packages have been removed from the Unity project, since they caused compilation errors when downgraded to 2019, and I didn't want to go through the hassle of resolving them without having to remove the packages outright.