### PR TITLE
feat: add DependencyScope utility class

### DIFF
--- a/Assets/UIComponents.Tests/DependencyScopeTests.cs
+++ b/Assets/UIComponents.Tests/DependencyScopeTests.cs
@@ -1,0 +1,49 @@
+﻿using NUnit.Framework;
+using UIComponents.Utilities;
+
+namespace UIComponents.Tests
+{
+    [TestFixture]
+    public class DependencyScopeTests
+    {
+        public interface IDependency {}
+        
+        public class DependencyClass : IDependency {}
+        
+        public class NewDependencyClass : IDependency {}
+
+        public class UIComponentWithNoDependencyAttribute : UIComponent
+        {
+            public IDependency GetDependency() => Provide<IDependency>();
+        }
+
+        [Dependency(typeof(IDependency), provide: typeof(DependencyClass))]
+        public class UIComponentWithDependency : UIComponentWithNoDependencyAttribute {}
+
+        [Test]
+        public void Should_Set_Dependency_And_Restore_Previous()
+        {
+            var component = new UIComponentWithDependency();
+            
+            using (new DependencyScope<UIComponentWithDependency, IDependency>(new NewDependencyClass()))
+            {
+                Assert.That(component.GetDependency(), Is.InstanceOf<NewDependencyClass>());
+            }
+            
+            Assert.That(component.GetDependency(), Is.InstanceOf<DependencyClass>());
+        }
+
+        [Test]
+        public void Should_Set_Dependency_And_Clear_It_If_No_Previous_Exists()
+        {
+            var component = new UIComponentWithNoDependencyAttribute();
+            
+            using (new DependencyScope<UIComponentWithNoDependencyAttribute, IDependency>(new NewDependencyClass()))
+            {
+                Assert.That(component.GetDependency(), Is.InstanceOf<NewDependencyClass>());
+            }
+
+            Assert.Throws<MissingProviderException>(() => component.GetDependency());
+        }
+    }
+}

--- a/Assets/UIComponents.Tests/DependencyScopeTests.cs.meta
+++ b/Assets/UIComponents.Tests/DependencyScopeTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 254e309568934e58b521710a4a902cb8
+timeCreated: 1652280678

--- a/Assets/UIComponents/Core/Utilities.meta
+++ b/Assets/UIComponents/Core/Utilities.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a78a9638ef554307839cb1ba217f2332
+timeCreated: 1652281867

--- a/Assets/UIComponents/Core/Utilities/DependencyScope.cs
+++ b/Assets/UIComponents/Core/Utilities/DependencyScope.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+namespace UIComponents.Utilities
+{
+    /// <summary>
+    /// A helper class for setting a dependency temporarily.
+    /// When disposed, restores the previous provider, or the lack thereof.
+    /// Built for unit tests.
+    /// </summary>
+    /// <typeparam name="TConsumer">Type of the consumer</typeparam>
+    /// <typeparam name="TDependency">Type of the dependency</typeparam>
+    public class DependencyScope<TConsumer, TDependency> : IDisposable
+        where TConsumer : class
+        where TDependency : class
+    {
+        private readonly TDependency _previousDependencyProvider;
+        
+        public DependencyScope(TDependency instance)
+        {
+            var injector = DependencyInjector.GetInjector(typeof(TConsumer));
+
+            if (injector.TryProvide<TDependency>(out var currentProvider))
+                _previousDependencyProvider = currentProvider;
+            
+            DependencyInjector.SetDependency<TConsumer, TDependency>(instance);
+        }
+        
+        public void Dispose()
+        {
+            if (_previousDependencyProvider == null)
+                DependencyInjector.ClearDependency<TConsumer, TDependency>();
+            else
+                DependencyInjector.SetDependency<TConsumer, TDependency>(_previousDependencyProvider);
+        }
+    }
+}

--- a/Assets/UIComponents/Core/Utilities/DependencyScope.cs.meta
+++ b/Assets/UIComponents/Core/Utilities/DependencyScope.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 99ac67fc4aea4760aae5c17c8e3cb123
+timeCreated: 1652280505

--- a/README.md
+++ b/README.md
@@ -229,6 +229,28 @@ public void TearDown()
 }
 ```
 
+A `DependencyScope` helper class is available under the `UIComponents.Utilities` namespace.
+
+```c#
+[Dependency(typeof(ICounterService), provide: typeof(CounterService))]
+public class CounterComponent : UIComponent {}
+```
+```c#
+using UIComponents.Utilities;
+
+[Test]
+public void It_Works()
+{
+    var service = new MockCounterService();
+    using (new DependencyScope<CounterComponent, ICounterService>(service))
+    {
+        // MockCounterService will be provided for CounterComponent
+    }
+    
+    // CounterService will be provided
+}
+```
+
 ## Loading assets
 
 ### Resources


### PR DESCRIPTION
This PR adds a `DependencyScope` class, which makes switching dependencies easier in unit tests.