### PR TITLE
ci(unity): add 2022.1.0f1, remove WebGL & Windows32 platforms

### DIFF
--- a/.github/workflows/unity.yml
+++ b/.github/workflows/unity.yml
@@ -22,11 +22,11 @@ jobs:
           - 2019.4.38f1
           - 2020.3.33f1
           - 2021.3.1f1
+          - 2022.1.0f1
         targetPlatform:
           - StandaloneLinux64
           - iOS
           - Android
-          - WebGL
             
     steps:
       - uses: actions/checkout@v3
@@ -82,8 +82,8 @@ jobs:
           unityVersion: ${{ matrix.unityVersion }}
           targetPlatform: ${{ matrix.targetPlatform }}
 
-  buildForWindowsBasedPlatforms:
-    name: Build for ${{ matrix.targetPlatform }} on ${{ matrix.unityVersion }}
+  buildForWindows:
+    name: Build for 64-bit Windows on ${{ matrix.unityVersion }}
     runs-on: windows-2019
     strategy:
       fail-fast: false
@@ -92,9 +92,7 @@ jobs:
           - 2019.4.38f1
           - 2020.3.33f1
           - 2021.3.1f1
-        targetPlatform:
-          - StandaloneWindows
-          - StandaloneWindows64
+          - 2022.1.0f1
 
     steps:
       - uses: actions/checkout@v3
@@ -104,10 +102,10 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: Library
-          key: Library-${{ matrix.targetPlatform }}-${{ matrix.unityVersion }}-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
+          key: Library-StandaloneWindows64-${{ matrix.unityVersion }}-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
           restore-keys: |
-            Library-${{ matrix.targetPlatform }}-${{ matrix.unityVersion }}-
-            Library-${{ matrix.targetPlatform }}-
+            Library-StandaloneWindows64-${{ matrix.unityVersion }}-
+            Library-StandaloneWindows64-
             Library-
             
       - uses: game-ci/unity-builder@v2
@@ -117,10 +115,10 @@ jobs:
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
         with:
           unityVersion: ${{ matrix.unityVersion }}
-          targetPlatform: ${{ matrix.targetPlatform }}
+          targetPlatform: StandaloneWindows64
 
-  buildForMacOSBasedPlatforms:
-    name: Build for ${{ matrix.targetPlatform }} on ${{ matrix.unityVersion }}
+  buildForMacOS:
+    name: Build for MacOS on ${{ matrix.unityVersion }}
     runs-on: macos-latest
     strategy:
       fail-fast: false
@@ -129,8 +127,7 @@ jobs:
           - 2019.4.38f1
           - 2020.3.33f1
           - 2021.3.1f1
-        targetPlatform:
-          - StandaloneOSX
+          - 2022.1.0f1
 
     steps:
       - uses: actions/checkout@v3
@@ -140,10 +137,10 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: Library
-          key: Library-${{ matrix.targetPlatform }}-${{ matrix.unityVersion }}-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
+          key: Library-StandaloneOSX-${{ matrix.unityVersion }}-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
           restore-keys: |
-            Library-${{ matrix.targetPlatform }}-${{ matrix.unityVersion }}-
-            Library-${{ matrix.targetPlatform }}-
+            Library-StandaloneOSX-${{ matrix.unityVersion }}-
+            Library-StandaloneOSX-
             Library-
 
       - uses: game-ci/unity-builder@v2
@@ -153,4 +150,4 @@ jobs:
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
         with:
           unityVersion: ${{ matrix.unityVersion }}
-          targetPlatform: ${{ matrix.targetPlatform }}
+          targetPlatform: StandaloneOSX


### PR DESCRIPTION
I have removed the WebGL and Windows 32-bit platforms from CI as I don't believe they bring any value at the moment. Testing on 2022.1.0f1 is more valuable.

I may bring WebGL back if uicomponents gets runtime-focused features in the future.