### PR TITLE
feat: add experimental QueryAttribute

### DIFF
--- a/Assets/Samples/Query.meta
+++ b/Assets/Samples/Query.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5e064455a2b9429bbdb906a64c4dd8cd
+timeCreated: 1653672211

--- a/Assets/Samples/Query/Editor.meta
+++ b/Assets/Samples/Query/Editor.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c1aa1a4dc95a4f549279705f80bfeee1
+timeCreated: 1653672570

--- a/Assets/Samples/Query/Editor/QueryExampleComponentWindow.cs
+++ b/Assets/Samples/Query/Editor/QueryExampleComponentWindow.cs
@@ -1,0 +1,23 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace UIComponents.Samples.Query.Editor
+{
+    public class QueryExampleComponentWindow : EditorWindow
+    {
+        [MenuItem("UIComponents Examples/Experimental/QueryAttribute")]
+        private static void ShowWindow()
+        {
+            var window = GetWindow<QueryExampleComponentWindow>();
+            window.titleContent = new GUIContent("QueryAttribute");
+            window.Show();
+        }
+
+        private void CreateGUI()
+        {
+            rootVisualElement.style.minWidth = 190;
+            rootVisualElement.style.minHeight = 40;
+            rootVisualElement.Add(new QueryExampleComponent());
+        }
+    }
+}

--- a/Assets/Samples/Query/Editor/QueryExampleComponentWindow.cs.meta
+++ b/Assets/Samples/Query/Editor/QueryExampleComponentWindow.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7b53ed73de14469d9223ecc80ef747cf
+timeCreated: 1653672626

--- a/Assets/Samples/Query/Editor/UIComponents.Samples.Query.Editor.asmdef
+++ b/Assets/Samples/Query/Editor/UIComponents.Samples.Query.Editor.asmdef
@@ -1,0 +1,19 @@
+{
+    "name": "UIComponents.Samples.Query.Editor",
+    "rootNamespace": "UIComponents.Samples",
+    "references": [
+        "GUID:d593635333b4cae48bac5b5f0b596e90",
+        "GUID:d180e9959e2b4d2580f328c2e6aa239d"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Samples/Query/Editor/UIComponents.Samples.Query.Editor.asmdef.meta
+++ b/Assets/Samples/Query/Editor/UIComponents.Samples.Query.Editor.asmdef.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b5e89eceb4bc42369d3ebcecaae37637
+timeCreated: 1653672580

--- a/Assets/Samples/Query/QueryExampleComponent.cs
+++ b/Assets/Samples/Query/QueryExampleComponent.cs
@@ -1,0 +1,22 @@
+﻿using UIComponents.Experimental;
+using UnityEngine.UIElements;
+
+namespace UIComponents.Samples.Query
+{
+    [Layout("QueryExampleComponent")]
+    [Stylesheet("QueryExampleComponent.styles")]
+    public class QueryExampleComponent : UIComponent
+    {
+        [Query("my-label")]
+        public readonly Label MyLabel;
+    
+        [Query("my-foldout")]
+        public readonly Foldout MyFoldout;
+    
+        public QueryExampleComponent()
+        {
+            MyLabel.text = "This text was set in the component constructor.";
+            MyFoldout.Add(new Label("This label was added in the component constructor."));
+        }
+    }
+}

--- a/Assets/Samples/Query/QueryExampleComponent.cs.meta
+++ b/Assets/Samples/Query/QueryExampleComponent.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: bd2fd4665a254fc0a066d2062c6d1c07
+timeCreated: 1653672227

--- a/Assets/Samples/Query/Resources.meta
+++ b/Assets/Samples/Query/Resources.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e0122628124042bab0f570e1ef9905e6
+timeCreated: 1653672288

--- a/Assets/Samples/Query/Resources/QueryExampleComponent.styles.uss
+++ b/Assets/Samples/Query/Resources/QueryExampleComponent.styles.uss
@@ -1,0 +1,3 @@
+﻿Label {
+    white-space: normal;
+}

--- a/Assets/Samples/Query/Resources/QueryExampleComponent.styles.uss.meta
+++ b/Assets/Samples/Query/Resources/QueryExampleComponent.styles.uss.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 24fe3dbd40874e8790ff852f1a4acf80
+timeCreated: 1653672751

--- a/Assets/Samples/Query/Resources/QueryExampleComponent.uxml
+++ b/Assets/Samples/Query/Resources/QueryExampleComponent.uxml
@@ -1,0 +1,8 @@
+﻿<UXML xmlns:ui="UnityEngine.UIElements">
+    <ui:Label text="This is a component for demonstrating QueryAttribute, an experimental feature in UIComponents." />
+    <ui:Label text="QueryAttribute allows for populating UIComponent fields automatically." />
+    <ui:Label name="my-label" text="" />
+    <ui:Foldout name="my-foldout" text="Foldout...">
+        <ui:Label text="Foldout content" />
+    </ui:Foldout>
+</UXML>

--- a/Assets/Samples/Query/Resources/QueryExampleComponent.uxml.meta
+++ b/Assets/Samples/Query/Resources/QueryExampleComponent.uxml.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f499b0f65470467cac6fe062472ca90a
+timeCreated: 1653672370

--- a/Assets/Samples/Query/UIComponents.Samples.Query.asmdef
+++ b/Assets/Samples/Query/UIComponents.Samples.Query.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "UIComponents.Samples.Query",
+    "rootNamespace": "UIComponents.Samples",
+    "references": [
+        "GUID:d593635333b4cae48bac5b5f0b596e90"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Samples/Query/UIComponents.Samples.Query.asmdef.meta
+++ b/Assets/Samples/Query/UIComponents.Samples.Query.asmdef.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d180e9959e2b4d2580f328c2e6aa239d
+timeCreated: 1653672350

--- a/Assets/UIComponents.Benchmarks/BenchmarkUtils.cs
+++ b/Assets/UIComponents.Benchmarks/BenchmarkUtils.cs
@@ -4,7 +4,7 @@ namespace UIComponents.Benchmarks
 {
     public static class BenchmarkUtils
     {
-        public const string Version = "0.9.0.0";
+        public const string Version = "0.9.0.1";
         
         private static SampleGroup[] GetProfilerMarkers()
         {
@@ -12,7 +12,8 @@ namespace UIComponents.Benchmarks
             {
                 new SampleGroup("UIComponent.DependencySetup", SampleUnit.Microsecond),
                 new SampleGroup("UIComponent.CacheSetup", SampleUnit.Microsecond),
-                new SampleGroup("UIComponent.LayoutAndStylesSetup", SampleUnit.Microsecond)
+                new SampleGroup("UIComponent.LayoutAndStylesSetup", SampleUnit.Microsecond),
+                new SampleGroup("UIComponent.QueryFieldsSetup", SampleUnit.Microsecond)
             };
         }
         

--- a/Assets/UIComponents.Tests/QueryAttributeTests.cs
+++ b/Assets/UIComponents.Tests/QueryAttributeTests.cs
@@ -1,0 +1,31 @@
+﻿using NUnit.Framework;
+using UIComponents.Experimental;
+using UnityEngine.UIElements;
+
+namespace UIComponents.Tests
+{
+    [TestFixture]
+    public class QueryAttributeTests
+    {
+        [Layout("UIComponentTests/LayoutAttributeTests")]
+        private class ComponentWithQueryAttribute : UIComponent
+        {
+            [Query("hello-world-label")]
+            public readonly Label HelloWorldLabel;
+            
+            [Query("test-foldout")]
+            public readonly Foldout TestFoldout;
+        }
+
+        [Test]
+        public void Should_Populate_Fields()
+        {
+            var component = new ComponentWithQueryAttribute();
+            
+            Assert.That(component.HelloWorldLabel, Is.InstanceOf<Label>());
+            Assert.That(component.HelloWorldLabel.text, Is.EqualTo("Hello world!"));
+            
+            Assert.That(component.TestFoldout, Is.InstanceOf<Foldout>());
+        }
+    }
+}

--- a/Assets/UIComponents.Tests/QueryAttributeTests.cs.meta
+++ b/Assets/UIComponents.Tests/QueryAttributeTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 48ef8894f34841959c3e25adf9eacd7a
+timeCreated: 1653671129

--- a/Assets/UIComponents.Tests/Resources/UIComponentTests/LayoutAttributeTests.uxml
+++ b/Assets/UIComponents.Tests/Resources/UIComponentTests/LayoutAttributeTests.uxml
@@ -1,3 +1,6 @@
 ﻿<UXML xmlns:ui="UnityEngine.UIElements">
-    <ui:Label text="Hello world!" />
+    <ui:Label name="hello-world-label" text="Hello world!" />
+    <ui:Foldout name="test-foldout">
+        <ui:Label text="Foldout content" />
+    </ui:Foldout>
 </UXML>

--- a/Assets/UIComponents/Core/Cache/FieldCache.cs
+++ b/Assets/UIComponents/Core/Cache/FieldCache.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using UIComponents.Experimental;
+
+namespace UIComponents.Cache
+{
+    public readonly struct FieldCache
+    {
+        public readonly Dictionary<FieldInfo, QueryAttribute> QueryAttributes;
+
+        public FieldCache(Type type)
+        {
+            var fieldInfos = type.GetFields(
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            
+            QueryAttributes = new Dictionary<FieldInfo, QueryAttribute>();
+
+            for (var i = 0; i < fieldInfos.Length; i++)
+            {
+                var queryAttribute = fieldInfos[i].GetCustomAttribute<QueryAttribute>();
+                if (queryAttribute != null)
+                    QueryAttributes[fieldInfos[i]] = queryAttribute;
+            }
+        }
+    }
+}

--- a/Assets/UIComponents/Core/Cache/FieldCache.cs.meta
+++ b/Assets/UIComponents/Core/Cache/FieldCache.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 987947093629f564989ef4412fb3566d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UIComponents/Core/Cache/UIComponentCache.cs
+++ b/Assets/UIComponents/Core/Cache/UIComponentCache.cs
@@ -10,10 +10,12 @@ namespace UIComponents.Cache
         public readonly LayoutAttribute LayoutAttribute;
         public readonly List<StylesheetAttribute> StylesheetAttributes;
         public readonly List<AssetPathAttribute> AssetPathAttributes;
+        public readonly FieldCache FieldCache;
 
         public UIComponentCache(Type componentType)
         {
             Attributes = componentType.GetCustomAttributes(true);
+            FieldCache = new FieldCache(componentType);
 
             LayoutAttribute = null;
             StylesheetAttributes = new List<StylesheetAttribute>();

--- a/Assets/UIComponents/Core/Experimental.meta
+++ b/Assets/UIComponents/Core/Experimental.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a87b61a662174c9197de92748fdf89bb
+timeCreated: 1653670917

--- a/Assets/UIComponents/Core/Experimental/QueryAttribute.cs
+++ b/Assets/UIComponents/Core/Experimental/QueryAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace UIComponents.Experimental
+{
+    [AttributeUsage(AttributeTargets.Field)]
+    public class QueryAttribute : Attribute
+    {
+        public readonly string Name;
+
+        public QueryAttribute(string name)
+        {
+            Name = name;
+        }
+    }
+}

--- a/Assets/UIComponents/Core/Experimental/QueryAttribute.cs.meta
+++ b/Assets/UIComponents/Core/Experimental/QueryAttribute.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9e6ea1797d4c43a3a1d97830c4bbea11
+timeCreated: 1653670950

--- a/Assets/UIComponents/Core/UIComponent.cs
+++ b/Assets/UIComponents/Core/UIComponent.cs
@@ -54,6 +54,9 @@ namespace UIComponents
             new ProfilerMarker("UIComponent.CacheSetup");
         private static readonly ProfilerMarker LayoutAndStylesSetupProfilerMarker =
             new ProfilerMarker("UIComponent.LayoutAndStylesSetup");
+        private static readonly ProfilerMarker QueryFieldsSetupProfilerMarker =
+            new ProfilerMarker("UIComponent.QueryFieldsSetup");
+
 
         /// <summary>
         /// UIComponent's constructor loads the configured layout and stylesheets.
@@ -76,6 +79,9 @@ namespace UIComponents
             LoadLayout();
             LoadStyles();
             LayoutAndStylesSetupProfilerMarker.End();
+            QueryFieldsSetupProfilerMarker.Begin();
+            PopulateQueryFields();
+            QueryFieldsSetupProfilerMarker.End();
         }
         
         /// <summary>
@@ -173,5 +179,20 @@ namespace UIComponents
                 if (loadedStyleSheets[i] != null)
                     styleSheets.Add(loadedStyleSheets[i]);
         }
+        
+        private void PopulateQueryFields()
+        {
+            var fieldCache = CacheDictionary[_componentType].FieldCache;
+            var queryAttributes = fieldCache.QueryAttributes;
+
+            foreach (var queryAttributeKeyPair in queryAttributes)
+            {
+                var fieldInfo = queryAttributeKeyPair.Key;
+                var queryAttribute = queryAttributeKeyPair.Value;
+
+                fieldInfo.SetValue(this, this.Q(queryAttribute.Name));
+            }
+        }
+
     }
 }

--- a/Assets/UIComponents/package.json
+++ b/Assets/UIComponents/package.json
@@ -30,6 +30,11 @@
             "displayName": "Asset Loading from Addressables",
             "description": "Contains an example of asset loading from Addressables.",
             "path": "Samples~/Addressables"
+        },
+        {
+            "displayName": "QueryAttribute (experimental)",
+            "description": "Contains an example of using QueryAttribute to populate fields.",
+            "path": "Samples~/Query"
         }
     ],
     "license": "MIT",

--- a/README.md
+++ b/README.md
@@ -112,6 +112,41 @@ loaded automatically.
 loaded automatically. Unlike `[Layout]`, multiple `[Stylesheet]`
 attributes can be used on a single UIComponent.
 
+## Experimental features
+
+`[Query]` is an experimental feature that allows for populating fields automatically.
+It is accessible via the `UIComponents.Experimental` namespace.
+
+```xml
+<!-- Resources/MyLayout.uxml -->
+<UXML xmlns:ui="UnityEngine.UIElements">
+    <ui:Label name="my-label" text="Hello world!" />
+    <ui:Foldout name="my-foldout">
+        <ui:Label text="Foldout content" />
+    </ui:Foldout>
+</UXML>
+```
+```c#
+using UIComponents;
+using UIComponents.Experimental;
+
+[Layout("MyLayout")]
+public class MyComponent : UIComponent
+{
+    [Query("my-label")]
+    public readonly Label MyLabel;
+    
+    [Query("my-foldout")]
+    public readonly Foldout MyFoldout;
+    
+    public MyComponent()
+    {
+        MyLabel.text = "Goodbye world!";
+        MyFoldout.Add(new Label("More content!"));
+    }
+}
+```
+
 ## Dependency injection
 
 ### Summary


### PR DESCRIPTION
This PR adds `[Query]`, an experimental feature that allows for populating fields automatically.

```xml
<!-- Resources/MyLayout.uxml -->
<UXML xmlns:ui="UnityEngine.UIElements">
    <ui:Label name="my-label" text="Hello world!" />
    <ui:Foldout name="my-foldout">
        <ui:Label text="Foldout content" />
    </ui:Foldout>
</UXML>
```
```c#
using UIComponents;
using UIComponents.Experimental;

[Layout("MyLayout")]
public class MyComponent : UIComponent
{
    [Query("my-label")]
    public readonly Label MyLabel;
    
    [Query("my-foldout")]
    public readonly Foldout MyFoldout;
    
    public MyComponent()
    {
        MyLabel.text = "Goodbye world!";
        MyFoldout.Add(new Label("More content!"));
    }
}
```