### PR TITLE
feat(StylesheetAttribute): apply stylesheets from parents upward

### DIFF
--- a/Assets/UIComponents.Tests/StylesheetAttributeTests.cs
+++ b/Assets/UIComponents.Tests/StylesheetAttributeTests.cs
@@ -54,9 +54,9 @@ namespace UIComponents.Tests
         public void Inherited_Stylesheets_Are_Loaded()
         {
             var component = new InheritedComponent();
-            _resolver.Received().LoadAsset<StyleSheet>("Assets/StylesheetThree.uss");
             _resolver.Received().LoadAsset<StyleSheet>("Assets/StylesheetOne.uss");
             _resolver.Received().LoadAsset<StyleSheet>("Assets/StylesheetTwo.uss");
+            _resolver.Received().LoadAsset<StyleSheet>("Assets/StylesheetThree.uss");
             Assert.That(component.styleSheets.count, Is.EqualTo(3));
         }
 

--- a/Assets/UIComponents/Core/Cache/UIComponentCache.cs
+++ b/Assets/UIComponents/Core/Cache/UIComponentCache.cs
@@ -22,7 +22,7 @@ namespace UIComponents.Cache
             AssetPathAttributes = new List<AssetPathAttribute>();
 
             LayoutAttribute = GetSingleAttribute<LayoutAttribute>();
-            PopulateAttributeList(StylesheetAttributes);
+            PopulateAttributeListParentsFirst(componentType, StylesheetAttributes);
             PopulateAttributeList(AssetPathAttributes);
         }
         
@@ -41,6 +41,26 @@ namespace UIComponents.Cache
             for (var i = 0; i < Attributes.Length; i++)
                 if (Attributes[i] is T castAttribute)
                     list.Add(castAttribute);
+        }
+
+        private static void PopulateAttributeListParentsFirst<T>(
+            Type componentType, ICollection<T> list) where T : Attribute
+        {
+            var uiComponentType = typeof(UIComponent);
+            var baseTypeList = new List<Type>();
+            
+            while (componentType != null && componentType != uiComponentType)
+            {
+                baseTypeList.Insert(0, componentType);
+                componentType = componentType.BaseType;
+            }
+            
+            foreach (var baseType in baseTypeList)
+            {
+                var attributes = (T[]) baseType.GetCustomAttributes(typeof(T), false);
+                for (var i = 0; i < attributes.Length; i++)
+                    list.Add(attributes[i]);
+            }
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -112,6 +112,24 @@ loaded automatically.
 loaded automatically. Unlike `[Layout]`, multiple `[Stylesheet]`
 attributes can be used on a single UIComponent.
 
+```c#
+using UIComponents;
+
+[Stylesheet("Assets/StylesheetOne.uss")]
+[Stylesheet("Assets/StylesheetTwo.uss")]
+public class UIComponentWithTwoStylesheets : UIComponent {}
+        
+[Stylesheet("Assets/StylesheetThree.uss")]
+public class ChildComponent : UIComponentWithTwoStylesheets {}
+```
+
+Stylesheets will be applied to `ChildComponent` in the following order:
+- `Assets/StylesheetOne.uss`
+- `Assets/StylesheetTwo.uss`
+- `Assets/StylesheetThree.uss`
+
+This means that child components can override styles from their parents.
+
 ## Experimental features
 
 `[Query]` is an experimental feature that allows for populating fields automatically.
@@ -156,8 +174,8 @@ Dependency injection requires an interface. Below is a simple example:
 ```c#
 public interface ICounterService
 {
-    public void IncrementCount();
-    public int GetCount();
+    void IncrementCount();
+    int GetCount();
 }
 
 public class CounterService : ICounterService


### PR DESCRIPTION
Stylesheets defined in parent classes are now loaded first. This means that child classes can override styles from their parents.