### PR TITLE
ci(unity): build & test on WebGL instead of mobile

### DIFF
--- a/.github/workflows/unity.yml
+++ b/.github/workflows/unity.yml
@@ -25,8 +25,7 @@ jobs:
           - 2022.1.0f1
         targetPlatform:
           - StandaloneLinux64
-          - iOS
-          - Android
+          - WebGL
             
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
I've seen mobile platforms failing often because of various download issues related to Gradle etc, so I'm ditching them in favor of WebGL.