### PR TITLE
DependencyInjector: allow restoring dependency specified by DependencyAttribute

### DIFF
--- a/Assets/UIComponents.Tests/DependencyInjectorStaticTests.cs
+++ b/Assets/UIComponents.Tests/DependencyInjectorStaticTests.cs
@@ -50,5 +50,20 @@ namespace UIComponents.Tests
                 Assert.That(DependencyInjector.InjectorDictionary.ContainsKey(componentType), Is.False);
             }
         }
+
+        [TestFixture]
+        public class RestoreDefaultDependency
+        {
+            [Test]
+            public void Restores_The_Default_Dependency_Instance()
+            {
+                var component = new UIComponentWithDependency();
+
+                DependencyInjector.ClearDependency<UIComponentWithDependency, IDependency>();
+                DependencyInjector.RestoreDefaultDependency<UIComponentWithDependency, IDependency>();
+                
+                Assert.That(component.GetDependency(), Is.InstanceOf<DependencyProvider>());
+            }
+        }
     }
 }

--- a/Assets/UIComponents.Tests/DependencyInjectorTests.cs
+++ b/Assets/UIComponents.Tests/DependencyInjectorTests.cs
@@ -126,5 +126,42 @@ namespace UIComponents.Tests
                 Assert.DoesNotThrow(() => injector.ClearDependency<IDependency>());
             }
         }
+
+        [TestFixture]
+        public class RestoreDefaultDependency
+        {
+            [Test]
+            public void Restores_Default_Dependency()
+            {
+                var dependencyAttribute =
+                    new DependencyAttribute(typeof(IDependency), typeof(DependencyOne));
+
+                var injector = new DependencyInjector(new[] {dependencyAttribute});
+                
+                injector.SetDependency<IDependency>(new DependencyTwo());
+
+                Assert.That(injector.Provide<IDependency>(), Is.InstanceOf<DependencyTwo>());
+                
+                injector.RestoreDefaultDependency<IDependency>();
+                
+                Assert.That(injector.Provide<IDependency>(), Is.InstanceOf<DependencyOne>());
+            }
+            
+            [Test]
+            public void Throws_If_No_Default_Dependency_Exists()
+            {
+                var injector = new DependencyInjector();
+                
+                Assert.Throws<InvalidOperationException>(
+                    () => injector.RestoreDefaultDependency<IDependency>()
+                );
+                
+                injector.SetDependency<IDependency>(new DependencyOne());
+                
+                Assert.Throws<InvalidOperationException>(
+                    () => injector.RestoreDefaultDependency<IDependency>()
+                );
+            }
+        }
     }
 }

--- a/Assets/UIComponents/Core/DependencyInjector.cs
+++ b/Assets/UIComponents/Core/DependencyInjector.cs
@@ -81,6 +81,10 @@ namespace UIComponents
         /// Restores the default dependency, which is the one
         /// set by <see cref="DependencyAttribute"/>.
         /// </summary>
+        /// <remarks>
+        /// Can be used in unit tests to clear
+        /// restore dependency between or after tests.
+        /// </remarks>
         /// <typeparam name="TConsumer">Consumer type</typeparam>
         /// <typeparam name="TDependency">Dependency type</typeparam>
         /// <exception cref="InvalidOperationException">

--- a/Assets/UIComponents/Core/DependencyInjector.cs
+++ b/Assets/UIComponents/Core/DependencyInjector.cs
@@ -24,7 +24,7 @@ namespace UIComponents
         /// </summary>
         internal static readonly Dictionary<Type, object> InstantiatedInstanceDictionary
             = new Dictionary<Type, object>();
-        
+
         /// <summary>
         /// Contains the dependencies the injector provides to its consumer.
         /// </summary>
@@ -48,8 +48,8 @@ namespace UIComponents
         /// <param name="provider">
         /// The new instance used for the dependency
         /// </param>
-        /// <typeparam name="TConsumer">Type of the consumer</typeparam>
-        /// <typeparam name="TDependency">Type of the dependency</typeparam>
+        /// <typeparam name="TConsumer">Consumer type</typeparam>
+        /// <typeparam name="TDependency">Dependency type</typeparam>
         public static void SetDependency<TConsumer, TDependency>(TDependency provider)
             where TConsumer : class
             where TDependency : class
@@ -66,8 +66,8 @@ namespace UIComponents
         /// Can be used in unit tests to clear
         /// a dependency between tests.
         /// </remarks>
-        /// <typeparam name="TConsumer">Type of the consumer</typeparam>
-        /// <typeparam name="TDependency">Type of the dependency</typeparam>
+        /// <typeparam name="TConsumer">Consumer type</typeparam>
+        /// <typeparam name="TDependency">Dependency type</typeparam>
         public static void ClearDependency<TConsumer, TDependency>()
             where TConsumer : class
             where TDependency : class
@@ -129,7 +129,7 @@ namespace UIComponents
 
             return injector;
         }
-
+        
         private static object CreateInstance(Type dependencyType)
         {
             object instance;

--- a/README.md
+++ b/README.md
@@ -274,6 +274,8 @@ public class OtherComponent : MyComponent {}
 
 ### Testing
 
+#### Switching dependencies
+
 `DependencyInjector`, the class responsible for handling dependencies,
 comes with the `SetDependency` static method.
 
@@ -292,19 +294,8 @@ A mock version of a dependency can be switched in during a test. When `CounterCo
 asks for `ICounterService`, it will receive the instance of `MockCounterService` created
 in the `OneTimeSetUp` function.
 
-`DependencyInjector` also comes with the `ClearDependency` static method which can be used to remove
-the instance of a dependency between tests.
-
-```c#
-[TearDown]
-public void TearDown()
-{
-    DependencyInjector.ClearDependency<CounterComponent, ICounterService>();
-    // Provide<ICounterService> inside CounterComponent will now throw a MissingProviderException
-}
-```
-
-A `DependencyScope` helper class is available under the `UIComponents.Utilities` namespace.
+The `DependencyScope` helper class is available under the `UIComponents.Utilities` namespace.
+It is useful for switching dependencies temporarily.
 
 ```c#
 [Dependency(typeof(ICounterService), provide: typeof(CounterService))]
@@ -325,6 +316,38 @@ public void It_Works()
     // CounterService will be provided
 }
 ```
+
+#### Clearing dependencies
+
+`DependencyInjector` also comes with the `ClearDependency` static method which can be used to remove
+the instance of a dependency between tests.
+
+```c#
+[TearDown]
+public void TearDown()
+{
+    DependencyInjector.ClearDependency<CounterComponent, ICounterService>();
+    // Provide<ICounterService> inside CounterComponent will now throw a MissingProviderException
+}
+```
+
+#### Restoring dependencies
+
+Use `RestoreDefaultDependency` to restore the dependency to its original value as
+specified in the `[Dependency]` attribute.
+
+```c#
+[TearDown]
+public void TearDown()
+{
+    DependencyInjector.RestoreDefaultDependency<CounterComponent, ICounterService>();
+    // Provide<ICounterService> inside CounterComponent will now yield
+    // an instance of the type specified in the component's Dependency attribute.
+}
+```
+
+If no `[Dependency]` attribute exists on the component, `RestoreDefaultDependency` will throw
+an exception.
 
 ## Loading assets
 


### PR DESCRIPTION
This PR adds the `RestoreDefaultDependency` method to `DependencyInjector`, which makes it possible to restore the dependency of a component.

```c#
[Dependency(typeof(IDependency), provide: typeof(DependencyClass))]
public class MyComponent : UIComponent {}

// ...

[TearDown]
public void TearDown()
{
    DependencyInjector.RestoreDefaultDependency<MyComponent, IDependency>();
}
```

After the `TearDown` function, `MyComponent` will receive the `DependencyClass` instance, negating any changes made to the dependency in the tests.
