### PR TITLE
feat(QueryAttribute): use MeansImplicitUseAttribute

### DIFF
--- a/Assets/UIComponents/Core/Experimental/QueryAttribute.cs
+++ b/Assets/UIComponents/Core/Experimental/QueryAttribute.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using JetBrains.Annotations;
 using UnityEngine.UIElements;
 
 namespace UIComponents.Experimental
@@ -27,6 +28,7 @@ namespace UIComponents.Experimental
     /// }
     /// </example>
     [AttributeUsage(AttributeTargets.Field, AllowMultiple = true)]
+    [MeansImplicitUse]
     public class QueryAttribute : Attribute
     {
         public string Name { get; set; }


### PR DESCRIPTION
This should cut down warnings in Rider, and probably other IDEs as well.