### PR TITLE
Add event interfaces

### DIFF
--- a/Assets/Samples/EventInterfaces.meta
+++ b/Assets/Samples/EventInterfaces.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 63234002ff0b45fcad7850058716917e
+timeCreated: 1654950218

--- a/Assets/Samples/EventInterfaces/Editor.meta
+++ b/Assets/Samples/EventInterfaces/Editor.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a9afe23cd96c46d29520f3fdd74c4e72
+timeCreated: 1654950228

--- a/Assets/Samples/EventInterfaces/Editor/EventInterfacesWindow.cs
+++ b/Assets/Samples/EventInterfaces/Editor/EventInterfacesWindow.cs
@@ -1,0 +1,23 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace UIComponents.Samples.EventInterfaces.Editor
+{
+    public class EventInterfacesWindow : EditorWindow
+    {
+        [MenuItem("UIComponents Examples/Event Interfaces")]
+        private static void ShowWindow()
+        {
+            var window = GetWindow<EventInterfacesWindow>();
+            window.titleContent = new GUIContent("Event Interfaces");
+            window.minSize = new Vector2(360, 100);
+            window.Show();
+        }
+
+        private void CreateGUI()
+        {
+            rootVisualElement.Add(new EventInterfacesView());
+        }
+    }
+}
+

--- a/Assets/Samples/EventInterfaces/Editor/EventInterfacesWindow.cs.meta
+++ b/Assets/Samples/EventInterfaces/Editor/EventInterfacesWindow.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: eb5f0b162bd247c0bcdfda0ccd13a5ae
+timeCreated: 1654950300

--- a/Assets/Samples/EventInterfaces/Editor/UIComponents.Samples.EventInterfaces.Editor.asmdef
+++ b/Assets/Samples/EventInterfaces/Editor/UIComponents.Samples.EventInterfaces.Editor.asmdef
@@ -1,0 +1,19 @@
+{
+    "name": "UIComponents.Samples.EventInterfaces.Editor",
+    "rootNamespace": "UIComponents",
+    "references": [
+        "GUID:d593635333b4cae48bac5b5f0b596e90",
+        "GUID:f5833962044a46a297739cc8c0bf6713"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Samples/EventInterfaces/Editor/UIComponents.Samples.EventInterfaces.Editor.asmdef.meta
+++ b/Assets/Samples/EventInterfaces/Editor/UIComponents.Samples.EventInterfaces.Editor.asmdef.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 09089a91b3d1449c96e9192b3b1bd07d
+timeCreated: 1654950280

--- a/Assets/Samples/EventInterfaces/EventInterfaceLog.cs
+++ b/Assets/Samples/EventInterfaces/EventInterfaceLog.cs
@@ -1,0 +1,51 @@
+﻿using UnityEngine.UIElements;
+
+namespace UIComponents.Samples.EventInterfaces
+{
+    [Layout("EventInterfaceLog")]
+    [Stylesheet("EventInterfaceLog.style")]
+    [Dependency(typeof(IEventLogService), provide: typeof(EventLogService))]
+    public class EventInterfaceLog : UIComponent
+    {
+        public new class UxmlFactory : UxmlFactory<EventInterfaceLog> {}
+
+        private readonly ScrollView _scrollView;
+        private readonly IEventLogService _eventLogService;
+
+        public EventInterfaceLog()
+        {
+            _scrollView = this.Q<ScrollView>("event-scroll-view");
+            _eventLogService = Provide<IEventLogService>();
+            
+            foreach (var message in _eventLogService.GetMessages())
+                _scrollView.Add(new Label(message));
+
+            _eventLogService.OnMessageAdd += OnLogMessageAdd;
+            _eventLogService.OnMessageChange += OnLogMessageChange;
+            _eventLogService.OnClear += OnLogClear;
+        }
+
+        ~EventInterfaceLog()
+        {
+            _eventLogService.OnMessageAdd -= OnLogMessageAdd;
+            _eventLogService.OnMessageChange -= OnLogMessageChange;
+            _eventLogService.OnClear -= OnLogClear;
+        }
+
+        private void OnLogMessageAdd(string message)
+        {
+            _scrollView.Add(new Label(message));
+        }
+
+        private void OnLogMessageChange(int index, string newMessage)
+        {
+            if (_scrollView[index] is Label label)
+                label.text = newMessage;
+        }
+
+        private void OnLogClear()
+        {
+            _scrollView.Clear();
+        }
+    }
+}

--- a/Assets/Samples/EventInterfaces/EventInterfaceLog.cs
+++ b/Assets/Samples/EventInterfaces/EventInterfaceLog.cs
@@ -10,12 +10,15 @@ namespace UIComponents.Samples.EventInterfaces
         public new class UxmlFactory : UxmlFactory<EventInterfaceLog> {}
 
         private readonly ScrollView _scrollView;
-        private readonly IEventLogService _eventLogService;
+        private readonly EventLogService _eventLogService;
 
         public EventInterfaceLog()
         {
             _scrollView = this.Q<ScrollView>("event-scroll-view");
-            _eventLogService = Provide<IEventLogService>();
+            
+            // Unity 2019 does not support interfaces with delegates and events,
+            // so we need to get the class itself
+            _eventLogService = Provide<IEventLogService>() as EventLogService;
             
             foreach (var message in _eventLogService.GetMessages())
                 _scrollView.Add(new Label(message));

--- a/Assets/Samples/EventInterfaces/EventInterfaceLog.cs.meta
+++ b/Assets/Samples/EventInterfaces/EventInterfaceLog.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 02364a647095489093bae1cef4b15b21
+timeCreated: 1654950495

--- a/Assets/Samples/EventInterfaces/EventInterfacesView.cs
+++ b/Assets/Samples/EventInterfaces/EventInterfacesView.cs
@@ -6,7 +6,10 @@ namespace UIComponents.Samples.EventInterfaces
     [Dependency(typeof(IEventLogService), provide: typeof(EventLogService))]
     public class EventInterfacesView : UIComponent,
         IOnAttachToPanel, IOnGeometryChanged, IOnDetachFromPanel,
-        IOnMouseLeave, IOnMouseEnter, IOnClick
+        IOnMouseLeave, IOnMouseEnter
+#if UNITY_2020_3_OR_NEWER
+        , IOnClick
+#endif
     {
         private readonly IEventLogService _eventLogService;
 
@@ -49,11 +52,13 @@ namespace UIComponents.Samples.EventInterfaces
             _eventLogService.Log(evt);
         }
 
+#if UNITY_2020_3_OR_NEWER
         public void OnClick(ClickEvent evt)
         {
             _eventLogService.Log(evt);
         }
-
+#endif
+        
         private void OnClearButtonClicked()
         {
             _eventLogService.Clear();

--- a/Assets/Samples/EventInterfaces/EventInterfacesView.cs
+++ b/Assets/Samples/EventInterfaces/EventInterfacesView.cs
@@ -6,7 +6,7 @@ namespace UIComponents.Samples.EventInterfaces
     [Dependency(typeof(IEventLogService), provide: typeof(EventLogService))]
     public class EventInterfacesView : UIComponent,
         IOnAttachToPanel, IOnGeometryChanged, IOnDetachFromPanel,
-        IOnMouseLeave, IOnMouseEnter
+        IOnMouseLeave, IOnMouseEnter, IOnClick
     {
         private readonly IEventLogService _eventLogService;
 
@@ -45,6 +45,11 @@ namespace UIComponents.Samples.EventInterfaces
         }
 
         public void OnMouseLeave(MouseLeaveEvent evt)
+        {
+            _eventLogService.Log(evt);
+        }
+
+        public void OnClick(ClickEvent evt)
         {
             _eventLogService.Log(evt);
         }

--- a/Assets/Samples/EventInterfaces/EventInterfacesView.cs
+++ b/Assets/Samples/EventInterfaces/EventInterfacesView.cs
@@ -4,7 +4,9 @@ namespace UIComponents.Samples.EventInterfaces
 {
     [Layout("EventInterfacesView")]
     [Dependency(typeof(IEventLogService), provide: typeof(EventLogService))]
-    public class EventInterfacesView : UIComponent, IOnAttachToPanel, IOnGeometryChanged, IOnDetachFromPanel
+    public class EventInterfacesView : UIComponent,
+        IOnAttachToPanel, IOnGeometryChanged, IOnDetachFromPanel,
+        IOnMouseLeave, IOnMouseEnter
     {
         private readonly IEventLogService _eventLogService;
 
@@ -33,6 +35,16 @@ namespace UIComponents.Samples.EventInterfaces
         }
 
         public void OnGeometryChanged(GeometryChangedEvent evt)
+        {
+            _eventLogService.Log(evt);
+        }
+
+        public void OnMouseEnter(MouseEnterEvent evt)
+        {
+            _eventLogService.Log(evt);
+        }
+
+        public void OnMouseLeave(MouseLeaveEvent evt)
         {
             _eventLogService.Log(evt);
         }

--- a/Assets/Samples/EventInterfaces/EventInterfacesView.cs
+++ b/Assets/Samples/EventInterfaces/EventInterfacesView.cs
@@ -1,0 +1,45 @@
+﻿using UnityEngine.UIElements;
+
+namespace UIComponents.Samples.EventInterfaces
+{
+    [Layout("EventInterfacesView")]
+    [Dependency(typeof(IEventLogService), provide: typeof(EventLogService))]
+    public class EventInterfacesView : UIComponent, IOnAttachToPanel, IOnGeometryChanged, IOnDetachFromPanel
+    {
+        private readonly IEventLogService _eventLogService;
+
+        private readonly Button _clearButton;
+        
+        public EventInterfacesView()
+        {
+            _eventLogService = Provide<IEventLogService>();
+            _clearButton = this.Q<Button>("log-clear-button");
+            _clearButton.clicked += OnClearButtonClicked;
+        }
+
+        ~EventInterfacesView()
+        {
+            _clearButton.clicked -= OnClearButtonClicked;
+        }
+
+        public void OnAttachToPanel(AttachToPanelEvent evt)
+        {
+            _eventLogService.Log(evt);
+        }
+
+        public void OnDetachFromPanel(DetachFromPanelEvent evt)
+        {
+            _eventLogService.Log(evt);
+        }
+
+        public void OnGeometryChanged(GeometryChangedEvent evt)
+        {
+            _eventLogService.Log(evt);
+        }
+
+        private void OnClearButtonClicked()
+        {
+            _eventLogService.Clear();
+        }
+    }
+}

--- a/Assets/Samples/EventInterfaces/EventInterfacesView.cs.meta
+++ b/Assets/Samples/EventInterfaces/EventInterfacesView.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 480634ee18a04dfbac0510c14c1d710d
+timeCreated: 1654950474

--- a/Assets/Samples/EventInterfaces/EventLogService.cs
+++ b/Assets/Samples/EventInterfaces/EventLogService.cs
@@ -8,9 +8,17 @@ namespace UIComponents.Samples.EventInterfaces
 {
     public class EventLogService : IEventLogService
     {
-        public event IEventLogService.OnMessageAddDelegate OnMessageAdd;
+        public delegate void OnMessageAddDelegate(string message);
 
-        public event IEventLogService.OnMessageChangeDelegate OnMessageChange;
+        public delegate void OnMessageChangeDelegate(int index, string newMessage);
+        
+        public event OnMessageAddDelegate OnMessageAdd;
+
+        public event OnMessageChangeDelegate OnMessageChange;
+        
+        public delegate void OnClearDelegate();
+
+        public event OnClearDelegate OnClear;
         
         private readonly List<string> _messages = new List<string>(20);
         private long _previousEventTypeId;
@@ -62,8 +70,6 @@ namespace UIComponents.Samples.EventInterfaces
             return StringBuilder.ToString();
         }
 
-        public event IEventLogService.OnClearDelegate OnClear;
-        
         public void Clear()
         {
             _messages.Clear();

--- a/Assets/Samples/EventInterfaces/EventLogService.cs
+++ b/Assets/Samples/EventInterfaces/EventLogService.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using UnityEngine.UIElements;
+
+namespace UIComponents.Samples.EventInterfaces
+{
+    public class EventLogService : IEventLogService
+    {
+        public event IEventLogService.OnMessageAddDelegate OnMessageAdd;
+
+        public event IEventLogService.OnMessageChangeDelegate OnMessageChange;
+        
+        private readonly List<string> _messages = new List<string>(20);
+        private long _previousEventTypeId;
+        private int _latestMessageDuplicateCount;
+
+        public void Log(EventBase evt)
+        {
+            if (evt.eventTypeId == _previousEventTypeId && _messages.Count > 0)
+                UpdateLatestLogMessage(evt);
+            else
+                AddLogMessage(evt);
+
+            _previousEventTypeId = evt.eventTypeId;
+        }
+
+        private void UpdateLatestLogMessage(EventBase evt)
+        {
+            _latestMessageDuplicateCount++;
+            var index = _messages.Count - 1;
+            var message = BuildMessageFromEvent(evt);
+            _messages[index] = message;
+            OnMessageChange?.Invoke(index, message);
+        }
+
+        private void AddLogMessage(EventBase evt)
+        {
+            _latestMessageDuplicateCount = 0;
+            var message = BuildMessageFromEvent(evt);
+            _messages.Add(message);
+            OnMessageAdd?.Invoke(message);
+        }
+
+        private static readonly StringBuilder StringBuilder
+            = new StringBuilder(100);
+
+        private string BuildMessageFromEvent(EventBase evt)
+        {
+            StringBuilder.Clear();
+
+            StringBuilder.Append("[");
+            StringBuilder.Append(DateTime.Now.ToString(CultureInfo.CurrentUICulture));
+            StringBuilder.Append("] ");
+
+            StringBuilder.Append(evt.GetType().Name);
+
+            if (_latestMessageDuplicateCount > 0)
+                StringBuilder.Append($" (x{_latestMessageDuplicateCount + 1})");
+
+            return StringBuilder.ToString();
+        }
+
+        public event IEventLogService.OnClearDelegate OnClear;
+        
+        public void Clear()
+        {
+            _messages.Clear();
+            OnClear?.Invoke();
+        }
+
+        public IReadOnlyList<string> GetMessages()
+        {
+            return _messages;
+        }
+    }
+}

--- a/Assets/Samples/EventInterfaces/EventLogService.cs.meta
+++ b/Assets/Samples/EventInterfaces/EventLogService.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2a1ef40a26b4439db42b25e098a01737
+timeCreated: 1654950569

--- a/Assets/Samples/EventInterfaces/IEventLogService.cs
+++ b/Assets/Samples/EventInterfaces/IEventLogService.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using UnityEngine.UIElements;
+
+namespace UIComponents.Samples.EventInterfaces
+{
+    public interface IEventLogService
+    {
+        delegate void OnMessageAddDelegate(string message);
+
+        event OnMessageAddDelegate OnMessageAdd;
+
+        delegate void OnMessageChangeDelegate(int index, string newMessage);
+
+        event OnMessageChangeDelegate OnMessageChange;
+
+        void Log(EventBase evt);
+
+        delegate void OnClearDelegate();
+
+        event OnClearDelegate OnClear;
+
+        void Clear();
+
+        IReadOnlyList<string> GetMessages();
+    }
+}

--- a/Assets/Samples/EventInterfaces/IEventLogService.cs
+++ b/Assets/Samples/EventInterfaces/IEventLogService.cs
@@ -5,19 +5,7 @@ namespace UIComponents.Samples.EventInterfaces
 {
     public interface IEventLogService
     {
-        delegate void OnMessageAddDelegate(string message);
-
-        event OnMessageAddDelegate OnMessageAdd;
-
-        delegate void OnMessageChangeDelegate(int index, string newMessage);
-
-        event OnMessageChangeDelegate OnMessageChange;
-
         void Log(EventBase evt);
-
-        delegate void OnClearDelegate();
-
-        event OnClearDelegate OnClear;
 
         void Clear();
 

--- a/Assets/Samples/EventInterfaces/IEventLogService.cs.meta
+++ b/Assets/Samples/EventInterfaces/IEventLogService.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7252ec17e82b4783bdb2cc5ba34d0c89
+timeCreated: 1654950610

--- a/Assets/Samples/EventInterfaces/Resources.meta
+++ b/Assets/Samples/EventInterfaces/Resources.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 82cc48f82d2f4492b95c0378ff72707a
+timeCreated: 1654950260

--- a/Assets/Samples/EventInterfaces/Resources/EventInterfaceLog.style.uss
+++ b/Assets/Samples/EventInterfaces/Resources/EventInterfaceLog.style.uss
@@ -1,0 +1,10 @@
+﻿#event-scroll-view {
+    margin: 16px;
+    padding: 6px;
+    background-color: darkslategrey;
+    border-radius: 8px;
+}
+
+#event-scroll-view Label {
+    color: orange;
+}

--- a/Assets/Samples/EventInterfaces/Resources/EventInterfaceLog.style.uss.meta
+++ b/Assets/Samples/EventInterfaces/Resources/EventInterfaceLog.style.uss.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 79860cdae7ec4968b6d255ccc90d3dfa
+timeCreated: 1654954268

--- a/Assets/Samples/EventInterfaces/Resources/EventInterfaceLog.uxml
+++ b/Assets/Samples/EventInterfaces/Resources/EventInterfaceLog.uxml
@@ -1,0 +1,3 @@
+﻿<UXML xmlns:ui="UnityEngine.UIElements">
+    <ui:ScrollView name="event-scroll-view" />
+</UXML>

--- a/Assets/Samples/EventInterfaces/Resources/EventInterfaceLog.uxml.meta
+++ b/Assets/Samples/EventInterfaces/Resources/EventInterfaceLog.uxml.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3817f2a2478a452fb67591194375c0bb
+timeCreated: 1654951216

--- a/Assets/Samples/EventInterfaces/Resources/EventInterfacesView.uxml
+++ b/Assets/Samples/EventInterfaces/Resources/EventInterfacesView.uxml
@@ -1,0 +1,5 @@
+﻿<UXML xmlns:ui="UnityEngine.UIElements" xmlns:ei="UIComponents.Samples.EventInterfaces">
+    <ui:Label text="This component listens for various events. You can see them appearing in the log below." />
+    <ui:Button name="log-clear-button" text="Clear" />
+    <ei:EventInterfaceLog />
+</UXML>

--- a/Assets/Samples/EventInterfaces/Resources/EventInterfacesView.uxml.meta
+++ b/Assets/Samples/EventInterfaces/Resources/EventInterfacesView.uxml.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 28b242336cc5413598b73d1de96acf10
+timeCreated: 1654950781

--- a/Assets/Samples/EventInterfaces/UIComponents.Samples.EventInterfaces.asmdef
+++ b/Assets/Samples/EventInterfaces/UIComponents.Samples.EventInterfaces.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "UIComponents.Samples.EventInterfaces",
+    "rootNamespace": "UIComponents",
+    "references": [
+        "GUID:d593635333b4cae48bac5b5f0b596e90"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Samples/EventInterfaces/UIComponents.Samples.EventInterfaces.asmdef.meta
+++ b/Assets/Samples/EventInterfaces/UIComponents.Samples.EventInterfaces.asmdef.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f5833962044a46a297739cc8c0bf6713
+timeCreated: 1654950248

--- a/Assets/UIComponents.Tests/Editor/Interfaces.meta
+++ b/Assets/UIComponents.Tests/Editor/Interfaces.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3c45a51b4c0d4a5896d8908ddf010e9a
+timeCreated: 1654947033

--- a/Assets/UIComponents.Tests/Editor/Interfaces/InterfacesTestEditorWindow.cs
+++ b/Assets/UIComponents.Tests/Editor/Interfaces/InterfacesTestEditorWindow.cs
@@ -1,0 +1,18 @@
+﻿using UnityEditor;
+using UnityEngine.UIElements;
+
+namespace UIComponents.Tests.Editor.Interfaces
+{
+    public class InterfacesTestEditorWindow : EditorWindow
+    {
+        private void CreateGUI()
+        {
+            rootVisualElement.Add(new Label("Hello world"));    
+        }
+
+        public void AddTestComponent(UIComponent component)
+        {
+            rootVisualElement.Add(component);
+        }
+    }
+}

--- a/Assets/UIComponents.Tests/Editor/Interfaces/InterfacesTestEditorWindow.cs.meta
+++ b/Assets/UIComponents.Tests/Editor/Interfaces/InterfacesTestEditorWindow.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 189930fec46840b593ed140af7a30078
+timeCreated: 1654947055

--- a/Assets/UIComponents.Tests/Editor/Interfaces/UIComponentInterfaceTests.cs
+++ b/Assets/UIComponents.Tests/Editor/Interfaces/UIComponentInterfaceTests.cs
@@ -83,5 +83,16 @@ namespace UIComponents.Tests.Editor.Interfaces
         {
             Assert_Registers_Event_Callback<UIComponentWithOnMouseLeave, MouseLeaveEvent>();
         }
+        
+        private class UIComponentWithOnClick : BaseTestComponent, IOnClick
+        {
+            public void OnClick(ClickEvent evt) => Fired = true;
+        }
+
+        [Test]
+        public void IOnClick_Registers_ClickEvent_Callback()
+        {
+            Assert_Registers_Event_Callback<UIComponentWithOnClick, ClickEvent>();
+        }
     }
 }

--- a/Assets/UIComponents.Tests/Editor/Interfaces/UIComponentInterfaceTests.cs
+++ b/Assets/UIComponents.Tests/Editor/Interfaces/UIComponentInterfaceTests.cs
@@ -61,5 +61,27 @@ namespace UIComponents.Tests.Editor.Interfaces
         {
             Assert_Registers_Event_Callback<UIComponentWithOnDetachFromPanel, DetachFromPanelEvent>();
         }
+        
+        private class UIComponentWithOnMouseEnter : BaseTestComponent, IOnMouseEnter
+        {
+            public void OnMouseEnter(MouseEnterEvent evt) => Fired = true;
+        }
+
+        [Test]
+        public void IOnMouseEnter_Registers_MouseEnterEvent_Callback()
+        {
+            Assert_Registers_Event_Callback<UIComponentWithOnMouseEnter, MouseEnterEvent>();
+        }
+        
+        private class UIComponentWithOnMouseLeave : BaseTestComponent, IOnMouseLeave
+        {
+            public void OnMouseLeave(MouseLeaveEvent evt) => Fired = true;
+        }
+
+        [Test]
+        public void IOnMouseLeave_Registers_MouseLeaveEvent_Callback()
+        {
+            Assert_Registers_Event_Callback<UIComponentWithOnMouseLeave, MouseLeaveEvent>();
+        }
     }
 }

--- a/Assets/UIComponents.Tests/Editor/Interfaces/UIComponentInterfaceTests.cs
+++ b/Assets/UIComponents.Tests/Editor/Interfaces/UIComponentInterfaceTests.cs
@@ -84,6 +84,7 @@ namespace UIComponents.Tests.Editor.Interfaces
             Assert_Registers_Event_Callback<UIComponentWithOnMouseLeave, MouseLeaveEvent>();
         }
         
+#if UNITY_2020_3_OR_NEWER
         private class UIComponentWithOnClick : BaseTestComponent, IOnClick
         {
             public void OnClick(ClickEvent evt) => Fired = true;
@@ -94,5 +95,6 @@ namespace UIComponents.Tests.Editor.Interfaces
         {
             Assert_Registers_Event_Callback<UIComponentWithOnClick, ClickEvent>();
         }
+#endif
     }
 }

--- a/Assets/UIComponents.Tests/Editor/Interfaces/UIComponentInterfaceTests.cs
+++ b/Assets/UIComponents.Tests/Editor/Interfaces/UIComponentInterfaceTests.cs
@@ -1,0 +1,65 @@
+﻿using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace UIComponents.Tests.Editor.Interfaces
+{
+    [TestFixture]
+    public class UIComponentInterfaceTests
+    {
+        private class BaseTestComponent : UIComponent
+        {
+            public bool Fired { get; protected set; }
+        }
+
+        private static void Assert_Registers_Event_Callback<TComponent, TEvent>()
+            where TComponent : BaseTestComponent, new()
+            where TEvent : EventBase<TEvent>, new()
+        {
+            var window = EditorWindow.GetWindow<InterfacesTestEditorWindow>();
+            var component = new TComponent();
+            Assert.That(component.Fired, Is.False);
+            window.AddTestComponent(component);
+
+            using (var evt = new TEvent() { target = component })
+                component.SendEvent(evt);
+
+            Assert.That(component.Fired, Is.True);
+            window.Close();
+        }
+        
+        private class UIComponentWithOnGeometryChanged : BaseTestComponent, IOnGeometryChanged
+        {
+            public void OnGeometryChanged(GeometryChangedEvent evt) => Fired = true;
+        }
+
+        [Test]
+        public void IOnGeometryChanged_Registers_GeometryChangedEvent_Callback()
+        {
+            Assert_Registers_Event_Callback<UIComponentWithOnGeometryChanged, GeometryChangedEvent>();
+        }
+
+        private class UIComponentWithOnAttachToPanel : BaseTestComponent, IOnAttachToPanel
+        {
+            public void OnAttachToPanel(AttachToPanelEvent evt) => Fired = true;
+        }
+        
+        [Test]
+        public void IOnAttachToPanel_Registers_AttachToPanelEvent_Callback()
+        {
+            Assert_Registers_Event_Callback<UIComponentWithOnAttachToPanel, AttachToPanelEvent>();
+        }
+
+        private class UIComponentWithOnDetachFromPanel : BaseTestComponent, IOnDetachFromPanel
+        {
+            public void OnDetachFromPanel(DetachFromPanelEvent evt) => Fired = true;
+        }
+
+        [Test]
+        public void IOnDetachFromPanel_Registers_DetachFromPanelEvent_Callback()
+        {
+            Assert_Registers_Event_Callback<UIComponentWithOnDetachFromPanel, DetachFromPanelEvent>();
+        }
+    }
+}

--- a/Assets/UIComponents.Tests/Editor/Interfaces/UIComponentInterfaceTests.cs.meta
+++ b/Assets/UIComponents.Tests/Editor/Interfaces/UIComponentInterfaceTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: cfb9b8aab4b649d4a148a0c5f7c81f71
+timeCreated: 1654887088

--- a/Assets/UIComponents/Core/EventInterfaces.meta
+++ b/Assets/UIComponents/Core/EventInterfaces.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ecbe3c9add2348dfa2ce23fb47c3ec3d
+timeCreated: 1654947601

--- a/Assets/UIComponents/Core/EventInterfaces/IOnAttachToPanel.cs
+++ b/Assets/UIComponents/Core/EventInterfaces/IOnAttachToPanel.cs
@@ -1,0 +1,15 @@
+﻿using JetBrains.Annotations;
+using UnityEngine.UIElements;
+
+namespace UIComponents
+{
+    /// <summary>
+    /// When implemented by a <see cref="UIComponent"/>,
+    /// a callback for <see cref="AttachToPanelEvent"/> is
+    /// automatically registered in the UIComponent constructor.
+    /// </summary>
+    public interface IOnAttachToPanel
+    {
+        void OnAttachToPanel([NotNull] AttachToPanelEvent evt);
+    }
+}

--- a/Assets/UIComponents/Core/EventInterfaces/IOnAttachToPanel.cs.meta
+++ b/Assets/UIComponents/Core/EventInterfaces/IOnAttachToPanel.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4b2c01a4a686483c9c55084cd24d8394
+timeCreated: 1654886373

--- a/Assets/UIComponents/Core/EventInterfaces/IOnClick.cs
+++ b/Assets/UIComponents/Core/EventInterfaces/IOnClick.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine.UIElements;
+﻿#if UNITY_2020_3_OR_NEWER
+using UnityEngine.UIElements;
 
 namespace UIComponents
 {
@@ -12,3 +13,4 @@ namespace UIComponents
         void OnClick(ClickEvent evt);
     }
 }
+#endif

--- a/Assets/UIComponents/Core/EventInterfaces/IOnClick.cs
+++ b/Assets/UIComponents/Core/EventInterfaces/IOnClick.cs
@@ -1,0 +1,14 @@
+﻿using UnityEngine.UIElements;
+
+namespace UIComponents
+{
+    /// <summary>
+    /// When implemented by a <see cref="UIComponent"/>,
+    /// a callback for <see cref="ClickEvent"/> is
+    /// automatically registered in the UIComponent constructor.
+    /// </summary>
+    public interface IOnClick
+    {
+        void OnClick(ClickEvent evt);
+    }
+}

--- a/Assets/UIComponents/Core/EventInterfaces/IOnClick.cs.meta
+++ b/Assets/UIComponents/Core/EventInterfaces/IOnClick.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b569025dc42e4a67b078642bb95a13e0
+timeCreated: 1654956167

--- a/Assets/UIComponents/Core/EventInterfaces/IOnDetachFromPanel.cs
+++ b/Assets/UIComponents/Core/EventInterfaces/IOnDetachFromPanel.cs
@@ -1,0 +1,15 @@
+﻿using JetBrains.Annotations;
+using UnityEngine.UIElements;
+
+namespace UIComponents
+{
+    /// <summary>
+    /// When implemented by a <see cref="UIComponent"/>,
+    /// a callback for <see cref="DetachFromPanelEvent"/> is
+    /// automatically registered in the UIComponent constructor.
+    /// </summary>
+    public interface IOnDetachFromPanel
+    {
+        void OnDetachFromPanel([NotNull] DetachFromPanelEvent evt);
+    }
+}

--- a/Assets/UIComponents/Core/EventInterfaces/IOnDetachFromPanel.cs.meta
+++ b/Assets/UIComponents/Core/EventInterfaces/IOnDetachFromPanel.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 967a3c450b8f42b99c3289277686db4a
+timeCreated: 1654947641

--- a/Assets/UIComponents/Core/EventInterfaces/IOnGeometryChanged.cs
+++ b/Assets/UIComponents/Core/EventInterfaces/IOnGeometryChanged.cs
@@ -1,0 +1,15 @@
+﻿using JetBrains.Annotations;
+using UnityEngine.UIElements;
+
+namespace UIComponents
+{
+    /// <summary>
+    /// When implemented by a <see cref="UIComponent"/>,
+    /// a callback for <see cref="GeometryChangedEvent"/> is
+    /// automatically registered in the UIComponent constructor.
+    /// </summary>
+    public interface IOnGeometryChanged
+    {
+        void OnGeometryChanged([NotNull] GeometryChangedEvent evt);
+    }
+}

--- a/Assets/UIComponents/Core/EventInterfaces/IOnGeometryChanged.cs.meta
+++ b/Assets/UIComponents/Core/EventInterfaces/IOnGeometryChanged.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 76640e81397231b468fb05b32165f51c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UIComponents/Core/EventInterfaces/IOnMouseEnter.cs
+++ b/Assets/UIComponents/Core/EventInterfaces/IOnMouseEnter.cs
@@ -1,0 +1,14 @@
+﻿using UnityEngine.UIElements;
+
+namespace UIComponents
+{
+    /// <summary>
+    /// When implemented by a <see cref="UIComponent"/>,
+    /// a callback for <see cref="MouseEnterEvent"/> is
+    /// automatically registered in the UIComponent constructor.
+    /// </summary>
+    public interface IOnMouseEnter
+    {
+        void OnMouseEnter(MouseEnterEvent evt);
+    }
+}

--- a/Assets/UIComponents/Core/EventInterfaces/IOnMouseEnter.cs.meta
+++ b/Assets/UIComponents/Core/EventInterfaces/IOnMouseEnter.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 463840a4afc14662a9b7027b07137417
+timeCreated: 1654954994

--- a/Assets/UIComponents/Core/EventInterfaces/IOnMouseLeave.cs
+++ b/Assets/UIComponents/Core/EventInterfaces/IOnMouseLeave.cs
@@ -1,0 +1,14 @@
+﻿using UnityEngine.UIElements;
+
+namespace UIComponents
+{
+    /// <summary>
+    /// When implemented by a <see cref="UIComponent"/>,
+    /// a callback for <see cref="MouseLeaveEvent"/> is
+    /// automatically registered in the UIComponent constructor.
+    /// </summary>
+    public interface IOnMouseLeave
+    {
+        void OnMouseLeave(MouseLeaveEvent evt);
+    }
+}

--- a/Assets/UIComponents/Core/EventInterfaces/IOnMouseLeave.cs.meta
+++ b/Assets/UIComponents/Core/EventInterfaces/IOnMouseLeave.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 43bef59a4a2d4e0eb8154c83b0410298
+timeCreated: 1654954963

--- a/Assets/UIComponents/Core/UIComponent.cs
+++ b/Assets/UIComponents/Core/UIComponent.cs
@@ -104,8 +104,10 @@ namespace UIComponents
             if (this is IOnMouseLeave onMouseLeave)
                 RegisterCallback<MouseLeaveEvent>(onMouseLeave.OnMouseLeave);
             
+#if UNITY_2020_3_OR_NEWER
             if (this is IOnClick onClick)
                 RegisterCallback<ClickEvent>(onClick.OnClick);
+#endif
         }
         
         /// <summary>

--- a/Assets/UIComponents/Core/UIComponent.cs
+++ b/Assets/UIComponents/Core/UIComponent.cs
@@ -83,6 +83,20 @@ namespace UIComponents
             QueryFieldsSetupProfilerMarker.Begin();
             PopulateQueryFields();
             QueryFieldsSetupProfilerMarker.End();
+            
+            RegisterEventInterfaceCallbacks();
+        }
+
+        private void RegisterEventInterfaceCallbacks()
+        {
+            if (this is IOnAttachToPanel onAttachToPanel)
+                RegisterCallback<AttachToPanelEvent>(onAttachToPanel.OnAttachToPanel);
+            
+            if (this is IOnDetachFromPanel onDetachFromPanel)
+                RegisterCallback<DetachFromPanelEvent>(onDetachFromPanel.OnDetachFromPanel);
+
+            if (this is IOnGeometryChanged onGeometryChanged)
+                RegisterCallback<GeometryChangedEvent>(onGeometryChanged.OnGeometryChanged);
         }
         
         /// <summary>

--- a/Assets/UIComponents/Core/UIComponent.cs
+++ b/Assets/UIComponents/Core/UIComponent.cs
@@ -103,6 +103,9 @@ namespace UIComponents
             
             if (this is IOnMouseLeave onMouseLeave)
                 RegisterCallback<MouseLeaveEvent>(onMouseLeave.OnMouseLeave);
+            
+            if (this is IOnClick onClick)
+                RegisterCallback<ClickEvent>(onClick.OnClick);
         }
         
         /// <summary>

--- a/Assets/UIComponents/Core/UIComponent.cs
+++ b/Assets/UIComponents/Core/UIComponent.cs
@@ -97,6 +97,12 @@ namespace UIComponents
 
             if (this is IOnGeometryChanged onGeometryChanged)
                 RegisterCallback<GeometryChangedEvent>(onGeometryChanged.OnGeometryChanged);
+            
+            if (this is IOnMouseEnter onMouseEnter)
+                RegisterCallback<MouseEnterEvent>(onMouseEnter.OnMouseEnter);
+            
+            if (this is IOnMouseLeave onMouseLeave)
+                RegisterCallback<MouseLeaveEvent>(onMouseLeave.OnMouseLeave);
         }
         
         /// <summary>

--- a/Assets/UIComponents/package.json
+++ b/Assets/UIComponents/package.json
@@ -35,6 +35,11 @@
             "displayName": "QueryAttribute (experimental)",
             "description": "Contains an example of using QueryAttribute to populate fields.",
             "path": "Samples~/Query"
+        },
+        {
+            "displayName": "Event interfaces",
+            "description": "Contains an example of using event interfaces.",
+            "path": "Samples~/EventInterfaces"
         }
     ],
     "license": "MIT",

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ The interfaces are:
 - `IOnGeometryChanged` for `GeometryChangedEvent`
 - `IOnMouseEnter` for `MouseEnterEvent`
 - `IOnMouseLeave` for `MouseLeaveEvent`
+- `IOnClick` for `ClickEvent`
 
 ```c#
 public class ComponentWithCallbacks : UIComponent,
@@ -163,7 +164,8 @@ public class ComponentWithCallbacks : UIComponent,
     IOnGeometryChanged,
     IOnDetachFromPanel,
     IOnMouseEnter,
-    IOnMouseLeave
+    IOnMouseLeave,
+    IOnClick
 {
     public void OnAttachToPanel(AttachToPanelEvent evt)
     {
@@ -189,6 +191,11 @@ public class ComponentWithCallbacks : UIComponent,
     public void OnMouseLeave(MouseLeaveEvent evt)
     {
         Debug.Log("Bye mouse");
+    }
+    
+    public void OnClick(ClickEvent evt)
+    {
+        Debug.Log("Clicked!");
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -145,6 +145,37 @@ Stylesheets will be applied to `ChildComponent` in the following order:
 
 This means that child components can override styles from their parents.
 
+## Event interfaces
+
+UIComponents supports a number of event interfaces. When implemented, the callbacks
+are automatically registered in the UIComponent constructor.
+
+The interfaces are:
+- `IOnAttachToPanel` for `AttachToPanelEvent`
+- `IOnDetachFromPanel` for `DetachFromPanelEvent`
+- `IOnGeometryChanged` for `GeometryChangedEvent`
+
+```c#
+public class ComponentWithCallbacks : UIComponent, IOnAttachToPanel, IOnGeometryChanged, IOnDetachFromPanel
+{
+    public void OnAttachToPanel(AttachToPanelEvent evt)
+    {
+        Debug.Log("Hello world");
+    }
+    
+    public void OnGeometryChanged(GeometryChangedEvent evt)
+    {
+        Debug.Log("Geometry changed");
+        UnregisterCallback<GeometryChangedEvent>(OnGeometryChanged);
+    }
+    
+    public void OnDetachFromPanel(DetachFromPanelEvent evt)
+    {
+        Debug.Log("Goodbye world");
+    }
+}
+```
+
 ## Experimental features
 
 `[Query]` is an experimental feature that allows for populating fields automatically.

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ The interfaces are:
 - `IOnGeometryChanged` for `GeometryChangedEvent`
 - `IOnMouseEnter` for `MouseEnterEvent`
 - `IOnMouseLeave` for `MouseLeaveEvent`
-- `IOnClick` for `ClickEvent`
+- `IOnClick` for `ClickEvent` (requires Unity 2020+)
 
 ```c#
 public class ComponentWithCallbacks : UIComponent,

--- a/README.md
+++ b/README.md
@@ -154,9 +154,16 @@ The interfaces are:
 - `IOnAttachToPanel` for `AttachToPanelEvent`
 - `IOnDetachFromPanel` for `DetachFromPanelEvent`
 - `IOnGeometryChanged` for `GeometryChangedEvent`
+- `IOnMouseEnter` for `MouseEnterEvent`
+- `IOnMouseLeave` for `MouseLeaveEvent`
 
 ```c#
-public class ComponentWithCallbacks : UIComponent, IOnAttachToPanel, IOnGeometryChanged, IOnDetachFromPanel
+public class ComponentWithCallbacks : UIComponent,
+    IOnAttachToPanel,
+    IOnGeometryChanged,
+    IOnDetachFromPanel,
+    IOnMouseEnter,
+    IOnMouseLeave
 {
     public void OnAttachToPanel(AttachToPanelEvent evt)
     {
@@ -172,6 +179,16 @@ public class ComponentWithCallbacks : UIComponent, IOnAttachToPanel, IOnGeometry
     public void OnDetachFromPanel(DetachFromPanelEvent evt)
     {
         Debug.Log("Goodbye world");
+    }
+    
+    public void OnMouseEnter(MouseEnterEvent evt)
+    {
+        Debug.Log("Hi mouse");
+    }
+
+    public void OnMouseLeave(MouseLeaveEvent evt)
+    {
+        Debug.Log("Bye mouse");
     }
 }
 ```

--- a/UIElementsSchema/UIComponents.Samples.EventInterfaces.xsd
+++ b/UIElementsSchema/UIComponents.Samples.EventInterfaces.xsd
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:editor="UnityEditor.UIElements" xmlns:engine="UnityEngine.UIElements" xmlns="UnityEditor.PackageManager.UI" elementFormDefault="qualified" targetNamespace="UIComponents.Samples.EventInterfaces" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:import schemaLocation="UnityEngine.UIElements.xsd" namespace="UnityEngine.UIElements" />
+  <xs:complexType name="EventInterfaceLogType">
+    <xs:complexContent mixed="false">
+      <xs:restriction base="engine:VisualElementType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="engine:VisualElement" />
+        </xs:sequence>
+        <xs:attribute default="" name="name" type="xs:string" use="optional" />
+        <xs:attribute default="" name="view-data-key" type="xs:string" use="optional" />
+        <xs:attribute default="Position" name="picking-mode" type="engine:VisualElement_picking-mode_Type" use="optional" />
+        <xs:attribute default="" name="tooltip" type="xs:string" use="optional" />
+        <xs:attribute default="None" name="usage-hints" type="engine:VisualElement_usage-hints_Type" use="optional" />
+        <xs:attribute default="0" name="tabindex" type="xs:int" use="optional" />
+        <xs:attribute default="false" name="focusable" type="xs:boolean" use="optional" />
+        <xs:attribute default="" name="class" type="xs:string" use="optional" />
+        <xs:attribute default="" name="content-container" type="xs:string" use="optional" />
+        <xs:attribute default="" name="style" type="xs:string" use="optional" />
+        <xs:anyAttribute processContents="lax" />
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:element name="EventInterfaceLog" substitutionGroup="engine:VisualElement" xmlns:q1="UIComponents.Samples.EventInterfaces" type="q1:EventInterfaceLogType" />
+</xs:schema>

--- a/UIElementsSchema/UIElements.xsd
+++ b/UIElementsSchema/UIElements.xsd
@@ -3,8 +3,6 @@
   <xs:import schemaLocation="UnityEngine.UIElements.xsd" namespace="UnityEngine.UIElements" />
   <xs:import schemaLocation="UnityEditor.UIElements.xsd" namespace="UnityEditor.UIElements" />
   <xs:import schemaLocation="UnityEditor.UIElements.Debugger.xsd" namespace="UnityEditor.UIElements.Debugger" />
-  <xs:import schemaLocation="Unity.Cloud.Collaborate.Views.xsd" namespace="Unity.Cloud.Collaborate.Views" />
-  <xs:import schemaLocation="Unity.Cloud.Collaborate.Components.xsd" namespace="Unity.Cloud.Collaborate.Components" />
-  <xs:import schemaLocation="Unity.Cloud.Collaborate.Components.ChangeListEntries.xsd" namespace="Unity.Cloud.Collaborate.Components.ChangeListEntries" />
+  <xs:import schemaLocation="UIComponents.Samples.EventInterfaces.xsd" namespace="UIComponents.Samples.EventInterfaces" />
   <xs:import schemaLocation="UnityEditor.PackageManager.UI.xsd" namespace="UnityEditor.PackageManager.UI" />
 </xs:schema>


### PR DESCRIPTION
This PR adds a handful of event interfaces. When implemented, `UIComponent`'s constructor registers callbacks automatically.

```c#
public class Component : UIComponent, IOnGeometryChanged, IOnClick
{
    public void OnGeometryChanged(GeometryChangedEvent evt)
    {
        Debug.Log("Geometry changed");
    }

    public void OnClick(ClickEvent evt)
    {
        Debug.Log("Clicked");
    }
}
```