### PR TITLE
Add experimental ProvideAttribute

### DIFF
--- a/Assets/UIComponents.Benchmarks/BenchmarkUtils.cs
+++ b/Assets/UIComponents.Benchmarks/BenchmarkUtils.cs
@@ -4,7 +4,7 @@ namespace UIComponents.Benchmarks
 {
     public static class BenchmarkUtils
     {
-        public const string Version = "0.11.0.0";
+        public const string Version = "0.16.0.0";
         
         private static SampleGroup[] GetProfilerMarkers()
         {
@@ -13,7 +13,7 @@ namespace UIComponents.Benchmarks
                 new SampleGroup("UIComponent.DependencySetup", SampleUnit.Microsecond),
                 new SampleGroup("UIComponent.CacheSetup", SampleUnit.Microsecond),
                 new SampleGroup("UIComponent.LayoutAndStylesSetup", SampleUnit.Microsecond),
-                new SampleGroup("UIComponent.QueryFieldsSetup", SampleUnit.Microsecond)
+                new SampleGroup("UIComponent.PopulateFields", SampleUnit.Microsecond)
             };
         }
         

--- a/Assets/UIComponents.Tests/ProvideAttributeTests.cs
+++ b/Assets/UIComponents.Tests/ProvideAttributeTests.cs
@@ -1,0 +1,69 @@
+﻿using NSubstitute;
+using NUnit.Framework;
+using UIComponents.Experimental;
+using UIComponents.Utilities;
+
+namespace UIComponents.Tests
+{
+    [TestFixture]
+    public class ProvideAttributeTests
+    {
+        private interface IStringProperty
+        {
+            string Property { get; set; }
+        }
+        
+        private class StringClass : IStringProperty
+        {
+            public string Property { get; set; }
+        }
+        
+        private interface IFloatProperty
+        {
+            float Property { get; set; }
+        }
+        
+        private class FloatClass : IFloatProperty
+        {
+            public float Property { get; set; }
+        }
+
+        [Dependency(typeof(IStringProperty), provide: typeof(StringClass))]
+        [Dependency(typeof(IFloatProperty), provide: typeof(FloatClass))]
+        private class ComponentWithDependencies : UIComponent
+        {
+            [Provide]
+            public readonly IStringProperty StringProperty;
+            [Provide]
+            public readonly IFloatProperty FloatProperty;
+        }
+        
+        [Test]
+        public void Provides_Dependencies_Automatically()
+        {
+            var component = new ComponentWithDependencies();
+            Assert.That(component.StringProperty, Is.InstanceOf<StringClass>());
+            Assert.That(component.FloatProperty, Is.InstanceOf<FloatClass>());
+        }
+        
+        private class ComponentWithInvalidDependency : UIComponent
+        {
+            [Provide]
+            public readonly IStringProperty StringProperty;
+        }
+        
+        [Test]
+        public void Does_Not_Throw_When_Provider_Is_Missing()
+        {
+            var logger = Substitute.For<IUIComponentLogger>();
+
+            ComponentWithInvalidDependency component;
+            
+            using (new DependencyScope<ComponentWithInvalidDependency, IUIComponentLogger>(logger))
+                component = new ComponentWithInvalidDependency();
+            
+            Assert.That(component.StringProperty, Is.Null);
+            logger.Received().LogError("Could not provide IStringProperty to StringProperty", component);
+        }
+    }
+}

--- a/Assets/UIComponents.Tests/ProvideAttributeTests.cs.meta
+++ b/Assets/UIComponents.Tests/ProvideAttributeTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a08fe9b287ca462298e3636246b053df
+timeCreated: 1656052787

--- a/Assets/UIComponents/Core/Cache/FieldCache.cs
+++ b/Assets/UIComponents/Core/Cache/FieldCache.cs
@@ -11,6 +11,7 @@ namespace UIComponents.Cache
     public readonly struct FieldCache
     {
         public readonly Dictionary<FieldInfo, QueryAttribute[]> QueryAttributes;
+        public readonly Dictionary<FieldInfo, ProvideAttribute> ProvideAttributes;
 
         public FieldCache(Type type)
         {
@@ -18,13 +19,18 @@ namespace UIComponents.Cache
                 BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
             
             QueryAttributes = new Dictionary<FieldInfo, QueryAttribute[]>();
+            ProvideAttributes = new Dictionary<FieldInfo, ProvideAttribute>();
 
             for (var i = 0; i < fieldInfos.Length; i++)
             {
                 var queryAttributes = (QueryAttribute[]) fieldInfos[i].GetCustomAttributes<QueryAttribute>();
+                var provideAttribute = fieldInfos[i].GetCustomAttribute<ProvideAttribute>();
 
                 if (queryAttributes.Length > 0)
                     QueryAttributes[fieldInfos[i]] = queryAttributes;
+
+                if (provideAttribute != null)
+                    ProvideAttributes[fieldInfos[i]] = provideAttribute;
             }
         }
     }

--- a/Assets/UIComponents/Core/DependencyInjection/DependencyInjector.cs
+++ b/Assets/UIComponents/Core/DependencyInjection/DependencyInjector.cs
@@ -240,6 +240,24 @@ namespace UIComponents
         }
         
         /// <summary>
+        /// Returns a dependency. Throws a <see cref="MissingProviderException"/>
+        /// if the dependency can not be provided.
+        /// </summary>
+        /// <param name="type">Dependency type</param>
+        /// <returns>Dependency instance</returns>
+        /// <exception cref="MissingProviderException">
+        /// Thrown if the dependency can not be provided
+        /// </exception>
+        [NotNull]
+        public object Provide(Type type)
+        {
+            if (!DependencyDictionary.ContainsKey(type))
+                throw new MissingProviderException(type);
+            
+            return DependencyDictionary[type];
+        }
+        
+        /// <summary>
         /// Attempts to fetch a dependency. Returns whether
         /// the dependency could be fetched.
         /// </summary>

--- a/Assets/UIComponents/Core/Experimental/ProvideAttribute.cs
+++ b/Assets/UIComponents/Core/Experimental/ProvideAttribute.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using JetBrains.Annotations;
+
+namespace UIComponents.Experimental
+{
+    /// <summary>
+    /// An attribute for specifying a field to be automatically
+    /// assigned using dependency injection in UIComponents.
+    /// If no provider exists for the dependency, the field
+    /// is left unassigned and an error is logged.
+    /// </summary>
+    /// <example>
+    /// [Dependency(typeof(ILogger), provide: typeof(MyLogger)]
+    /// [Dependency(typeof(IDataService), provide: typeof(DataService)]
+    /// public class ComponentWithDependencies : UIComponent
+    /// {
+    ///     [Provide]
+    ///     private readonly ILogger Logger;
+    ///
+    ///     [Provide]
+    ///     private readonly IDataService DataService;
+    /// }
+    /// </example>
+    /// <seealso cref="DependencyAttribute"/>
+    [AttributeUsage(AttributeTargets.Field)]
+    [MeansImplicitUse]
+    public class ProvideAttribute : Attribute
+    {
+        
+    }
+}

--- a/Assets/UIComponents/Core/Experimental/ProvideAttribute.cs.meta
+++ b/Assets/UIComponents/Core/Experimental/ProvideAttribute.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4f608686be1c4c8eb8ee65b8677e02e2
+timeCreated: 1656051537

--- a/README.md
+++ b/README.md
@@ -264,8 +264,8 @@ See the dependency injection section below for more information on dependencies.
 using UIComponents;
 using UIComponents.Experimental;
 
-[Dependency(typeof(ISettingsService), provide: typeof(SettingsService)]
-[Dependency(typeof(IDataService), provide: typeof(DataService)]
+[Dependency(typeof(ISettingsService), provide: typeof(SettingsService))]
+[Dependency(typeof(IDataService), provide: typeof(DataService))]
 public class ComponentWithDependencies : UIComponent, IOnAttachToPanel
 {
     [Provide]

--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ public class ComponentWithCallbacks : UIComponent,
 
 ## Experimental features
 
+### QueryAttribute
+
 `[Query]` is an experimental feature that allows for populating fields automatically.
 It is accessible via the `UIComponents.Experimental` namespace.
 
@@ -247,6 +249,31 @@ public class MyComponent : UIComponent
     {
         HelloWorldLabel.text = "Goodbye world!";
         TestFoldout.Add(new Label("More content!"));
+    }
+}
+```
+
+### ProvideAttribute
+
+`[Provide]` will provide dependencies for you. It is accessible via the
+`UIComponents.Experimental` namespace.
+
+```c#
+using UIComponents;
+using UIComponents.Experimental;
+
+[Dependency(typeof(ISettingsService), provide: typeof(SettingsService)]
+[Dependency(typeof(IDataService), provide: typeof(DataService)]
+public class ComponentWithDependencies : UIComponent, IOnAttachToPanel
+{
+    [Provide]
+    private readonly ISettingsService SettingsService;
+    [Provide]
+    private readonly IDataService DataService;
+    
+    public void OnAttachToPanel(AttachToPanelEvent evt)
+    {
+        DataService.LoadData();
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -258,6 +258,8 @@ public class MyComponent : UIComponent
 `[Provide]` will provide dependencies for you. It is accessible via the
 `UIComponents.Experimental` namespace.
 
+See the dependency injection section below for more information on dependencies.
+
 ```c#
 using UIComponents;
 using UIComponents.Experimental;


### PR DESCRIPTION
This PR adds `[Provide]`, which can be used to populate fields with dependencies in UIComponents.

```c#
using UIComponents;
using UIComponents.Experimental;

[Dependency(typeof(ISettingsService), provide: typeof(SettingsService))]
[Dependency(typeof(IDataService), provide: typeof(DataService))]
public class ComponentWithDependencies : UIComponent, IOnAttachToPanel
{
    [Provide]
    private readonly ISettingsService SettingsService;
    [Provide]
    private readonly IDataService DataService;
    
    public void OnAttachToPanel(AttachToPanelEvent evt)
    {
        DataService.LoadData();
    }
}
```