### PR TITLE
Add RootClassAttribute

### DIFF
--- a/Assets/UIComponents.Tests/RootClassAttributeTests.cs
+++ b/Assets/UIComponents.Tests/RootClassAttributeTests.cs
@@ -1,0 +1,31 @@
+﻿using NUnit.Framework;
+
+namespace UIComponents.Tests
+{
+    [TestFixture]
+    public class RootClassAttributeTests
+    {
+        [RootClass("test-class")]
+        private class ComponentWithRootClass : UIComponent {}
+
+        [Test]
+        public void Adds_Class_To_Component()
+        {
+            var component = new ComponentWithRootClass();
+            Assert.That(component.ClassListContains("test-class"), Is.True);
+        }
+        
+        [RootClass("other-test-class")]
+        [RootClass("final-test-class")]
+        private class ChildComponentWithRootClass : ComponentWithRootClass {}
+        
+        [Test]
+        public void Adds_Class_To_Component_And_Child_Component()
+        {
+            var component = new ChildComponentWithRootClass();
+            Assert.That(component.ClassListContains("test-class"), Is.True);
+            Assert.That(component.ClassListContains("other-test-class"), Is.True);
+            Assert.That(component.ClassListContains("final-test-class"), Is.True);
+        }
+    }
+}

--- a/Assets/UIComponents.Tests/RootClassAttributeTests.cs.meta
+++ b/Assets/UIComponents.Tests/RootClassAttributeTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 798e24cea44f4597a7ee238e37ecdcd7
+timeCreated: 1656057719

--- a/Assets/UIComponents.Tests/UIComponentEffectAttributeTests.cs
+++ b/Assets/UIComponents.Tests/UIComponentEffectAttributeTests.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace UIComponents.Tests
+{
+    [TestFixture]
+    public class UIComponentEffectAttributeTests
+    {
+        [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+        private class TestEffectAttribute : UIComponentEffectAttribute
+        {
+            public override void Apply(UIComponent component) {}
+        }
+        
+        [TestEffect]
+        [TestEffect(Priority = -2)]
+        [TestEffect(Priority = 5)]
+        private class UIComponentWithEffects : UIComponent {}
+
+        [Test]
+        public void Effects_Are_Sorted_By_Priority()
+        {
+            var component = new UIComponentWithEffects();
+            
+            Assert.That(UIComponent.TryGetCache<UIComponentWithEffects>(out var cache), Is.True);
+            
+            Assert.That(cache.EffectAttributes.Count, Is.EqualTo(3));
+            Assert.That(cache.EffectAttributes[0].Priority, Is.EqualTo(5));
+            Assert.That(cache.EffectAttributes[1].Priority, Is.EqualTo(0));
+            Assert.That(cache.EffectAttributes[2].Priority, Is.EqualTo(-2));
+        }
+    }
+}

--- a/Assets/UIComponents.Tests/UIComponentEffectAttributeTests.cs.meta
+++ b/Assets/UIComponents.Tests/UIComponentEffectAttributeTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3c834104769f4f68a8fbf39f8d009832
+timeCreated: 1656057234

--- a/Assets/UIComponents/Core/Cache/UIComponentCache.cs
+++ b/Assets/UIComponents/Core/Cache/UIComponentCache.cs
@@ -13,6 +13,7 @@ namespace UIComponents.Cache
         public readonly LayoutAttribute LayoutAttribute;
         public readonly List<StylesheetAttribute> StylesheetAttributes;
         public readonly List<AssetPathAttribute> AssetPathAttributes;
+        public readonly List<UIComponentEffectAttribute> EffectAttributes;
         public readonly FieldCache FieldCache;
 
         public UIComponentCache(Type componentType)
@@ -23,10 +24,14 @@ namespace UIComponents.Cache
             LayoutAttribute = null;
             StylesheetAttributes = new List<StylesheetAttribute>();
             AssetPathAttributes = new List<AssetPathAttribute>();
+            EffectAttributes = new List<UIComponentEffectAttribute>();
 
             LayoutAttribute = GetSingleAttribute<LayoutAttribute>();
             PopulateAttributeListParentsFirst(componentType, StylesheetAttributes);
             PopulateAttributeList(AssetPathAttributes);
+            PopulateAttributeList(EffectAttributes);
+            
+            EffectAttributes.Sort((first, second) => second.CompareTo(first));
         }
         
         [CanBeNull]

--- a/Assets/UIComponents/Core/RootClassAttribute.cs
+++ b/Assets/UIComponents/Core/RootClassAttribute.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace UIComponents
+{
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    public class RootClassAttribute : UIComponentEffectAttribute
+    {
+        private readonly string _className;
+        
+        public RootClassAttribute(string className)
+        {
+            _className = className;
+        }
+        
+        public override void Apply(UIComponent component)
+        {
+            component.AddToClassList(_className);
+        }
+    }
+}

--- a/Assets/UIComponents/Core/RootClassAttribute.cs.meta
+++ b/Assets/UIComponents/Core/RootClassAttribute.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3d350b9daf484fab80ffaf4378721d4f
+timeCreated: 1656056228

--- a/Assets/UIComponents/Core/UIComponent.cs
+++ b/Assets/UIComponents/Core/UIComponent.cs
@@ -87,6 +87,7 @@ namespace UIComponents
             LayoutAndStylesSetupProfilerMarker.Begin();
             LoadLayout();
             LoadStyles();
+            ApplyEffects();
             LayoutAndStylesSetupProfilerMarker.End();
             QueryFieldsSetupProfilerMarker.Begin();
             PopulateQueryFields();
@@ -221,6 +222,15 @@ namespace UIComponents
             for (var i = 0; i < styleSheetCount; i++)
                 if (loadedStyleSheets[i] != null)
                     styleSheets.Add(loadedStyleSheets[i]);
+        }
+
+        private void ApplyEffects()
+        {
+            var effectAttributes = CacheDictionary[_componentType].EffectAttributes;
+            var effectAttributeCount = effectAttributes.Count;
+            
+            for (var i = 0; i < effectAttributeCount; i++)
+                effectAttributes[i].Apply(this);
         }
 
         private static readonly Type VisualElementType = typeof(VisualElement);

--- a/Assets/UIComponents/Core/UIComponentEffectAttribute.cs
+++ b/Assets/UIComponents/Core/UIComponentEffectAttribute.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using JetBrains.Annotations;
+
+namespace UIComponents
+{
+    /// <summary>
+    /// An attribute used to apply effects to a <see cref="UIComponent"/>.
+    /// They are applied after the layout and assets have been loaded.
+    /// Attributes with higher priority are applied first.
+    /// </summary>
+    [BaseTypeRequired(typeof(UIComponent))]
+    public abstract class UIComponentEffectAttribute : Attribute, IComparable<UIComponentEffectAttribute>
+    {
+        public int Priority { get; set; } = 0;
+        
+        public abstract void Apply(UIComponent component);
+        
+        public int CompareTo(UIComponentEffectAttribute other)
+        {
+            return Priority.CompareTo(other.Priority);
+        }
+    }
+}

--- a/Assets/UIComponents/Core/UIComponentEffectAttribute.cs.meta
+++ b/Assets/UIComponents/Core/UIComponentEffectAttribute.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 66b56fb227644b018488e3ef6f149108
+timeCreated: 1656056011

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ To update, change `upm/v0.15.0` to point to the latest version.
 
 ## Layouts and stylesheets
 
+### LayoutAttribute
+
 `[Layout]` allows specifying the path to a UXML file. The file will be
 loaded automatically. A component can have a single `[Layout]` attribute. It can be
 inherited from a parent class.
@@ -125,6 +127,8 @@ public class UIComponentWithOverriddenLayout : UIComponentWithLayout
 }
 ```
 
+### StylesheetAttribute
+
 `[Stylesheet]` allows specifying paths to USS files. The files will be
 loaded automatically. Unlike `[Layout]`, multiple `[Stylesheet]`
 attributes can be used on a single UIComponent.
@@ -144,6 +148,24 @@ Stylesheets will be applied to `ChildComponent` in the following order:
 - `Assets/StylesheetThree.uss`
 
 This means that child components can override styles from their parents.
+
+### RootClassAttribute
+
+`[RootClass]` allows specifying the name of a class that will be added
+to the root element of the UIComponent.
+
+```css
+/* Common.uss */
+
+.root {
+    background-color: #ff0000;
+}
+```
+```c#
+[Stylesheet("Common")]
+[RootClass("root")]
+public class UIComponentWithRootClass : UIComponent {}
+```
 
 ## Event interfaces
 


### PR DESCRIPTION
This PR adds `[RootClass]`, which can be used to add a class to a component's root element.

```css
/* Common.uss */

.root {
    background-color: #ff0000;
}
```
```c#
[Stylesheet("Common")]
[RootClass("root")]
public class UIComponentWithRootClass : UIComponent {}
```