### PR TITLE
Add support for transient dependencies

### DIFF
--- a/Assets/UIComponents.Benchmarks/AssetLoading/AddressablesAssetLoadBenchmarks.cs
+++ b/Assets/UIComponents.Benchmarks/AssetLoading/AddressablesAssetLoadBenchmarks.cs
@@ -11,7 +11,7 @@ namespace UIComponents.Benchmarks.AssetLoading
         [Layout("AddressablesExampleComponent.uxml")]
         [Stylesheet("AddressablesExampleComponent.uss")]
         [Stylesheet("Box.uss")]
-        [Dependency(typeof(IAssetResolver), provide: typeof(AddressableAssetResolver))]
+        [Dependency(typeof(IAssetResolver), provide: typeof(AddressableAssetResolver), Scope.Transient)]
         private class ComponentWithAssets : UIComponent {}
 
         [Test, Performance, Version(BenchmarkUtils.Version)]

--- a/Assets/UIComponents.Benchmarks/AssetLoading/AssetDatabaseAssetLoadBenchmarks.cs
+++ b/Assets/UIComponents.Benchmarks/AssetLoading/AssetDatabaseAssetLoadBenchmarks.cs
@@ -10,7 +10,7 @@ namespace UIComponents.Benchmarks.AssetLoading
         [Stylesheet("AssetDatabaseStylesFile.uss")]
         [Stylesheet("CommonMargins.uss")]
         [AssetPath("Assets/UIComponents.Benchmarks/AssetLoading")]
-        [Dependency(typeof(IAssetResolver), provide: typeof(AssetDatabaseAssetResolver))]
+        [Dependency(typeof(IAssetResolver), provide: typeof(AssetDatabaseAssetResolver), Scope.Transient)]
         private class ComponentWithAssets : UIComponent {}
 
         [Test, Performance, Version(BenchmarkUtils.Version)]

--- a/Assets/UIComponents.Benchmarks/BenchmarkUtils.cs
+++ b/Assets/UIComponents.Benchmarks/BenchmarkUtils.cs
@@ -4,7 +4,7 @@ namespace UIComponents.Benchmarks
 {
     public static class BenchmarkUtils
     {
-        public const string Version = "0.17.0.0";
+        public const string Version = "0.18.0.0";
         
         private static SampleGroup[] GetProfilerMarkers()
         {
@@ -23,7 +23,7 @@ namespace UIComponents.Benchmarks
                 .SetUp(() =>
                 {
                     UIComponent.ClearCache<TComponent>();
-                    DependencyInjector.RemoveInjector(typeof(TComponent));
+                    DependencyInjector.Container.Clear();
                 })
                 .SampleGroup(new SampleGroup("Cold Cache Time", SampleUnit.Microsecond))
                 .ProfilerMarkers(GetProfilerMarkers())

--- a/Assets/UIComponents.Benchmarks/BenchmarkUtils.cs
+++ b/Assets/UIComponents.Benchmarks/BenchmarkUtils.cs
@@ -10,10 +10,10 @@ namespace UIComponents.Benchmarks
         {
             return new[]
             {
-                new SampleGroup("UIComponent.DependencySetup", SampleUnit.Microsecond),
-                new SampleGroup("UIComponent.CacheSetup", SampleUnit.Microsecond),
-                new SampleGroup("UIComponent.LayoutAndStylesSetup", SampleUnit.Microsecond),
-                new SampleGroup("UIComponent.PopulateFields", SampleUnit.Microsecond)
+                new SampleGroup("UIComponent.DependencySetup"),
+                new SampleGroup("UIComponent.CacheSetup"),
+                new SampleGroup("UIComponent.LayoutAndStylesSetup"),
+                new SampleGroup("UIComponent.PopulateFields")
             };
         }
         
@@ -25,7 +25,7 @@ namespace UIComponents.Benchmarks
                     UIComponent.ClearCache<TComponent>();
                     DependencyInjector.Container.Clear();
                 })
-                .SampleGroup(new SampleGroup("Cold Cache Time", SampleUnit.Microsecond))
+                .SampleGroup(new SampleGroup("Cold Cache Time"))
                 .ProfilerMarkers(GetProfilerMarkers())
                 .MeasurementCount(50)
                 .IterationsPerMeasurement(100)
@@ -36,7 +36,7 @@ namespace UIComponents.Benchmarks
         public static void MeasureComponentInitWithWarmCache<TComponent>() where TComponent : UIComponent, new()
         {
             Measure.Method(() => { new TComponent(); })
-                .SampleGroup(new SampleGroup("Warm Cache Time", SampleUnit.Microsecond))
+                .SampleGroup(new SampleGroup("Warm Cache Time"))
                 .MeasurementCount(50)
                 .IterationsPerMeasurement(100)
                 .ProfilerMarkers(GetProfilerMarkers())

--- a/Assets/UIComponents.Tests/AssetPathAttributeTests.cs
+++ b/Assets/UIComponents.Tests/AssetPathAttributeTests.cs
@@ -29,7 +29,7 @@ namespace UIComponents.Tests
         public void TearDown()
         {
             _resolver.ClearReceivedCalls();
-            DependencyInjector.RestoreDefaultDependency<UIComponentWithAssetPaths, IAssetResolver>();
+            DependencyInjector.ResetProvidedInstance<UIComponentWithAssetPaths, IAssetResolver>();
         }
 
         [Test]

--- a/Assets/UIComponents.Tests/DependencyInjectorStaticTests.cs
+++ b/Assets/UIComponents.Tests/DependencyInjectorStaticTests.cs
@@ -52,15 +52,15 @@ namespace UIComponents.Tests
         }
 
         [TestFixture]
-        public class RestoreDefaultDependency
+        public class ResetProvidedInstance
         {
             [Test]
-            public void Restores_The_Default_Dependency_Instance()
+            public void Resets_The_Dependency_Instance()
             {
                 var component = new UIComponentWithDependency();
 
                 DependencyInjector.ClearDependency<UIComponentWithDependency, IDependency>();
-                DependencyInjector.RestoreDefaultDependency<UIComponentWithDependency, IDependency>();
+                DependencyInjector.ResetProvidedInstance<UIComponentWithDependency, IDependency>();
                 
                 Assert.That(component.GetDependency(), Is.InstanceOf<DependencyProvider>());
             }

--- a/Assets/UIComponents.Tests/DependencyInjectorStaticTests.cs
+++ b/Assets/UIComponents.Tests/DependencyInjectorStaticTests.cs
@@ -45,9 +45,9 @@ namespace UIComponents.Tests
             {
                 var componentType = typeof(UIComponentWithDependency);
                 var injector = new DependencyInjector();
-                DependencyInjector.InjectorDictionary[componentType] = injector;
+                DependencyInjector.Container.InjectorDictionary[componentType] = injector;
                 DependencyInjector.RemoveInjector(componentType);
-                Assert.That(DependencyInjector.InjectorDictionary.ContainsKey(componentType), Is.False);
+                Assert.That(DependencyInjector.Container.InjectorDictionary.ContainsKey(componentType), Is.False);
             }
         }
 

--- a/Assets/UIComponents.Tests/DependencyInjectorTests.cs
+++ b/Assets/UIComponents.Tests/DependencyInjectorTests.cs
@@ -128,38 +128,21 @@ namespace UIComponents.Tests
         }
 
         [TestFixture]
-        public class RestoreDefaultDependency
+        public class ResetProvidedInstance
         {
             [SetUp]
             public void SetUp()
             {
                 DependencyInjector.Container.Clear();
             }
-            
-            [Test]
-            public void Restores_Default_Dependency()
-            {
-                var dependencyAttribute =
-                    new DependencyAttribute(typeof(IDependency), typeof(DependencyOne));
 
-                var injector = new DependencyInjector(new[] {dependencyAttribute});
-                
-                injector.SetDependency<IDependency>(new DependencyTwo());
-
-                Assert.That(injector.Provide<IDependency>(), Is.InstanceOf<DependencyTwo>());
-                
-                injector.RestoreDefaultDependency<IDependency>();
-                
-                Assert.That(injector.Provide<IDependency>(), Is.InstanceOf<DependencyOne>());
-            }
-            
             [Test]
             public void Throws_If_No_Default_Dependency_Exists()
             {
                 var injector = new DependencyInjector();
                 
                 Assert.Throws<InvalidOperationException>(
-                    () => injector.RestoreDefaultDependency<IDependency>()
+                    () => injector.ResetProvidedInstance<IDependency>()
                 );
                 
                 var initialDependency = new DependencyOne();
@@ -167,7 +150,7 @@ namespace UIComponents.Tests
                 injector.SetDependency<IDependency>(initialDependency);
                 
                 Assert.DoesNotThrow(
-                    () => injector.RestoreDefaultDependency<IDependency>()
+                    () => injector.ResetProvidedInstance<IDependency>()
                 );
             }
 
@@ -180,7 +163,7 @@ namespace UIComponents.Tests
                 
                 injector.SetDependency<IDependency>(singletonInstance);
                 injector.SetDependency<IDependency>(new DependencyTwo());
-                injector.RestoreDefaultDependency<IDependency>();
+                injector.ResetProvidedInstance<IDependency>();
 
                 Assert.That(injector.Provide<IDependency>(), Is.SameAs(singletonInstance));
             }
@@ -193,7 +176,7 @@ namespace UIComponents.Tests
                 
                 injector.SetDependency<IDependency>(transientInstance, Scope.Transient);
                 injector.SetDependency<IDependency>(new DependencyTwo());
-                injector.RestoreDefaultDependency<IDependency>();
+                injector.ResetProvidedInstance<IDependency>();
                 
                 Assert.That(injector.Provide<IDependency>(), Is.InstanceOf<DependencyOne>());
                 Assert.That(injector.Provide<IDependency>(), Is.Not.SameAs(transientInstance));

--- a/Assets/UIComponents.Tests/DependencyInjectorTests.cs
+++ b/Assets/UIComponents.Tests/DependencyInjectorTests.cs
@@ -130,6 +130,12 @@ namespace UIComponents.Tests
         [TestFixture]
         public class RestoreDefaultDependency
         {
+            [SetUp]
+            public void SetUp()
+            {
+                DependencyInjector.Container.Clear();
+            }
+            
             [Test]
             public void Restores_Default_Dependency()
             {
@@ -156,11 +162,41 @@ namespace UIComponents.Tests
                     () => injector.RestoreDefaultDependency<IDependency>()
                 );
                 
-                injector.SetDependency<IDependency>(new DependencyOne());
+                var initialDependency = new DependencyOne();
                 
-                Assert.Throws<InvalidOperationException>(
+                injector.SetDependency<IDependency>(initialDependency);
+                
+                Assert.DoesNotThrow(
                     () => injector.RestoreDefaultDependency<IDependency>()
                 );
+            }
+
+            [Test]
+            public void Restores_Singleton_Instance()
+            {
+                var injector = new DependencyInjector();
+
+                var singletonInstance = new DependencyOne();
+                
+                injector.SetDependency<IDependency>(singletonInstance);
+                injector.SetDependency<IDependency>(new DependencyTwo());
+                injector.RestoreDefaultDependency<IDependency>();
+
+                Assert.That(injector.Provide<IDependency>(), Is.SameAs(singletonInstance));
+            }
+
+            [Test]
+            public void Creates_New_Transient_Instance()
+            {
+                var injector = new DependencyInjector();
+                var transientInstance = new DependencyOne();
+                
+                injector.SetDependency<IDependency>(transientInstance, Scope.Transient);
+                injector.SetDependency<IDependency>(new DependencyTwo());
+                injector.RestoreDefaultDependency<IDependency>();
+                
+                Assert.That(injector.Provide<IDependency>(), Is.InstanceOf<DependencyOne>());
+                Assert.That(injector.Provide<IDependency>(), Is.Not.SameAs(transientInstance));
             }
         }
     }

--- a/Assets/UIComponents.Tests/DependencyTests.cs
+++ b/Assets/UIComponents.Tests/DependencyTests.cs
@@ -1,0 +1,40 @@
+﻿using NUnit.Framework;
+
+namespace UIComponents.Tests
+{
+    [TestFixture]
+    public class DependencyTests
+    {
+        private interface IInterface {}
+        
+        private class ClassThatImplementsInterface : IInterface {}
+        
+        private class ClassThatDoesNotImplementInterface {}
+        
+        [Test]
+        public void Constructor_Throws_On_Invalid_Instance()
+        {
+            Assert.That(() => new Dependency(typeof(IInterface), (object) null, Scope.Singleton), Throws.ArgumentNullException);
+            Assert.That(() => new Dependency(null, typeof(ClassThatImplementsInterface), Scope.Singleton), Throws.ArgumentNullException);
+            Assert.That(() => new Dependency(typeof(IInterface), typeof(ClassThatDoesNotImplementInterface), Scope.Singleton), Throws.ArgumentException);
+        }
+
+        [Test]
+        public void ChangeInstance_Throws_On_Invalid_Instance()
+        {
+            var dependency = new Dependency(typeof(IInterface), typeof(ClassThatImplementsInterface), Scope.Singleton);
+            
+            Assert.That(() => dependency.ChangeInstance(null), Throws.ArgumentNullException);
+            Assert.That(() => dependency.ChangeInstance(new ClassThatDoesNotImplementInterface()), Throws.ArgumentException);
+        }
+
+        [Test]
+        public void Clear_Sets_Instance_To_Null()
+        {
+            var dependency = new Dependency(typeof(IInterface), typeof(ClassThatImplementsInterface), Scope.Singleton);
+            Assert.That(dependency.Instance, Is.Not.Null);
+            dependency.Clear();
+            Assert.That(dependency.Instance, Is.Null);
+        }
+    }
+}

--- a/Assets/UIComponents.Tests/DependencyTests.cs.meta
+++ b/Assets/UIComponents.Tests/DependencyTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 24d92bf65ad5483b86e626918ada5c2f
+timeCreated: 1657459166

--- a/Assets/UIComponents.Tests/LayoutAttributeTests.cs
+++ b/Assets/UIComponents.Tests/LayoutAttributeTests.cs
@@ -47,10 +47,10 @@ namespace UIComponents.Tests
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {
-            DependencyInjector.RestoreDefaultDependency<UIComponentWithLayout, IAssetResolver>();
-            DependencyInjector.RestoreDefaultDependency<InheritedComponentWithoutAttribute, IAssetResolver>();
-            DependencyInjector.RestoreDefaultDependency<InheritedComponentWithAttribute, IAssetResolver>();
-            DependencyInjector.RestoreDefaultDependency<UIComponentWithNullLayout, IAssetResolver>();
+            DependencyInjector.ResetProvidedInstance<UIComponentWithLayout, IAssetResolver>();
+            DependencyInjector.ResetProvidedInstance<InheritedComponentWithoutAttribute, IAssetResolver>();
+            DependencyInjector.ResetProvidedInstance<InheritedComponentWithAttribute, IAssetResolver>();
+            DependencyInjector.ResetProvidedInstance<UIComponentWithNullLayout, IAssetResolver>();
         }
         
         [TearDown]

--- a/Assets/UIComponents.Tests/PathAttributeTests.cs
+++ b/Assets/UIComponents.Tests/PathAttributeTests.cs
@@ -39,8 +39,8 @@ namespace UIComponents.Tests
             [OneTimeTearDown]
             public void OneTimeTearDown()
             {
-                DependencyInjector.RestoreDefaultDependency<UIComponentWithValidAssetPath, IAssetResolver>();
-                DependencyInjector.RestoreDefaultDependency<UIComponentWithInvalidAssetPath, IAssetResolver>();
+                DependencyInjector.ResetProvidedInstance<UIComponentWithValidAssetPath, IAssetResolver>();
+                DependencyInjector.ResetProvidedInstance<UIComponentWithInvalidAssetPath, IAssetResolver>();
             }
 
             [Test]

--- a/Assets/UIComponents.Tests/StylesheetAttributeTests.cs
+++ b/Assets/UIComponents.Tests/StylesheetAttributeTests.cs
@@ -37,8 +37,8 @@ namespace UIComponents.Tests
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {
-            DependencyInjector.RestoreDefaultDependency<UIComponentWithTwoStylesheets, IAssetResolver>();
-            DependencyInjector.RestoreDefaultDependency<InheritedComponent, IAssetResolver>();
+            DependencyInjector.ResetProvidedInstance<UIComponentWithTwoStylesheets, IAssetResolver>();
+            DependencyInjector.ResetProvidedInstance<InheritedComponent, IAssetResolver>();
         }
         
         [TearDown]

--- a/Assets/UIComponents.Tests/UIComponentDependencyTests.cs
+++ b/Assets/UIComponents.Tests/UIComponentDependencyTests.cs
@@ -80,5 +80,36 @@ namespace UIComponents.Tests
             Assert.That(component.DependencyWasProvided, Is.False);
             Assert.That(component.StringDependency, Is.Null);
         }
+        
+        [Dependency(typeof(IStringDependency), provide: typeof(StringProvider), Scope.Transient)]
+        private class UIComponentWithTransientDependencyA : UIComponent
+        {
+            public readonly IStringDependency StringDependency;
+            
+            public UIComponentWithTransientDependencyA()
+            {
+                StringDependency = Provide<IStringDependency>();
+            }
+        }
+        
+        [Dependency(typeof(IStringDependency), provide: typeof(StringProvider), Scope.Transient)]
+        private class UIComponentWithTransientDependencyB : UIComponent
+        {
+            public readonly IStringDependency StringDependency;
+            
+            public UIComponentWithTransientDependencyB()
+            {
+                StringDependency = Provide<IStringDependency>();
+            }
+        }
+        
+        [Test]
+        public void Transient_Dependencies_Are_Not_Cached()
+        {
+            var componentA = new UIComponentWithTransientDependencyA();
+            var componentB = new UIComponentWithTransientDependencyB();
+            
+            Assert.That(componentA.StringDependency, Is.Not.SameAs(componentB.StringDependency));
+        }
     }
 }

--- a/Assets/UIComponents.Tests/UIComponentNoAttributesTests.cs
+++ b/Assets/UIComponents.Tests/UIComponentNoAttributesTests.cs
@@ -22,7 +22,7 @@ namespace UIComponents.Tests
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {
-            DependencyInjector.RestoreDefaultDependency<UIComponentNoAttributes, IAssetResolver>();
+            DependencyInjector.ResetProvidedInstance<UIComponentNoAttributes, IAssetResolver>();
         }
         
         [TearDown]

--- a/Assets/UIComponents/Core/AssemblyInfo.cs
+++ b/Assets/UIComponents/Core/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 ﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("UIComponents.Tests")]
+[assembly: InternalsVisibleTo("UIComponents.Benchmarks")]

--- a/Assets/UIComponents/Core/DependencyInjection/Dependency.cs
+++ b/Assets/UIComponents/Core/DependencyInjection/Dependency.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using JetBrains.Annotations;
+
+namespace UIComponents
+{
+    /// <summary>
+    /// An internal class for provided dependencies.
+    /// </summary>
+    internal class Dependency
+    {
+        /// <summary>
+        /// The instance of the dependency which is provided to consumers.
+        /// </summary>
+        public object Instance { get; private set; }
+        
+        /// <summary>
+        /// The type of the provider the dependency was initialized
+        /// with.
+        /// </summary>
+        public Type InitialProviderType { get; }
+        
+        /// <summary>
+        /// The scope of the dependency.
+        /// </summary>
+        public Scope Scope { get; }
+
+        private readonly Type _dependencyType;
+        
+        /// <summary>
+        /// Initializes a new Dependency with a provided instance.
+        /// </summary>
+        /// <param name="dependencyType">Dependency type</param>
+        /// <param name="instance">Provided instance</param>
+        /// <param name="scope">Dependency scope</param>
+        /// <exception cref="ArgumentNullException">Thrown if arguments are null</exception>
+        /// <exception cref="ArgumentException">Thrown if the instance is not of the dependency type</exception>
+        public Dependency([NotNull] Type dependencyType, [NotNull] object instance, Scope scope)
+        {
+            if (dependencyType == null)
+                throw new ArgumentNullException(nameof(dependencyType));
+            
+            if (instance == null)
+                throw new ArgumentNullException(nameof(instance));
+            
+            _dependencyType = dependencyType;
+            Scope = scope;
+            
+            if (!_dependencyType.IsInstanceOfType(instance))
+                throw new ArgumentException("Instance is not of type " + _dependencyType.Name);
+            
+            Instance = instance;
+            InitialProviderType = instance.GetType();
+        }
+
+        /// <summary>
+        /// Initializes a new Dependency with a provider type.
+        /// Activator.CreateInstance is used to create an instance.
+        /// </summary>
+        /// <param name="dependencyType">Dependency type</param>
+        /// <param name="providerType">Provider type</param>
+        /// <param name="scope">Dependency scope</param>
+        /// <exception cref="ArgumentNullException">Thrown if arguments are null</exception>
+        public Dependency([NotNull] Type dependencyType, [NotNull] Type providerType, Scope scope) :
+            this(dependencyType, Activator.CreateInstance(providerType), scope) {}
+
+        /// <summary>
+        /// Changes the provided instance. It must be of the correct type.
+        /// </summary>
+        /// <param name="instance">New instance to provide</param>
+        /// <exception cref="ArgumentNullException">Thrown if instance is null</exception>
+        /// <exception cref="ArgumentException">Thrown if instance is not of the dependency type</exception>
+        public void ChangeInstance([NotNull] object instance)
+        {
+            if (instance == null)
+                throw new ArgumentNullException(nameof(instance));
+            
+            if (!_dependencyType.IsInstanceOfType(instance))
+                throw new ArgumentException("Instance is not of type " + _dependencyType.Name);
+
+            Instance = instance;
+        }
+
+        /// <summary>
+        /// Clears the provided instance.
+        /// </summary>
+        public void Clear()
+        {
+            Instance = null;
+        }
+    }
+}

--- a/Assets/UIComponents/Core/DependencyInjection/Dependency.cs.meta
+++ b/Assets/UIComponents/Core/DependencyInjection/Dependency.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3856d5988d004303bc4e0a99d3f2e3a0
+timeCreated: 1657428494

--- a/Assets/UIComponents/Core/DependencyInjection/DependencyAttribute.cs
+++ b/Assets/UIComponents/Core/DependencyInjection/DependencyAttribute.cs
@@ -13,10 +13,13 @@ namespace UIComponents
 
         public readonly Type ProvideType;
 
-        public DependencyAttribute(Type dependency, Type provide)
+        public readonly Scope Scope;
+
+        public DependencyAttribute(Type dependency, Type provide, Scope scope = Scope.Singleton)
         {
             DependencyType = dependency;
             ProvideType = provide;
+            Scope = scope;
         }
     }
 }

--- a/Assets/UIComponents/Core/DependencyInjection/DependencyInjector.cs
+++ b/Assets/UIComponents/Core/DependencyInjection/DependencyInjector.cs
@@ -13,30 +13,15 @@ namespace UIComponents
     public class DependencyInjector
     {
         /// <summary>
-        /// Contains all injectors created for consumers.
+        /// A container used with the static DependencyInjector methods.
         /// </summary>
-        internal static readonly Dictionary<Type, DependencyInjector> InjectorDictionary =
-            new Dictionary<Type, DependencyInjector>();
-        
-        /// <summary>
-        /// Contains the instantiated dependencies which are consumed
-        /// by the interested parties.
-        /// </summary>
-        internal static readonly Dictionary<Type, object> InstantiatedInstanceDictionary
-            = new Dictionary<Type, object>();
+        internal static readonly DiContainer Container = new DiContainer();
 
         /// <summary>
         /// Contains the dependencies the injector provides to its consumer.
         /// </summary>
-        internal readonly Dictionary<Type, object> DependencyDictionary
-            = new Dictionary<Type, object>();
-        
-        /// <summary>
-        /// Contains the default provider types for each dependency of the consumer.
-        /// Populated by <see cref="DependencyAttribute"/>.
-        /// </summary>
-        internal readonly Dictionary<Type, Type> DefaultDependencyTypeDictionary
-            = new Dictionary<Type, Type>();
+        private readonly Dictionary<Type, Dependency> _dependencyDictionary
+            = new Dictionary<Type, Dependency>();
 
         /// <summary>
         /// Switches the dependency of a consumer.
@@ -106,10 +91,7 @@ namespace UIComponents
         /// <returns>Injector of the consumer type</returns>
         public static DependencyInjector GetInjector(Type consumerType)
         {
-            if (InjectorDictionary.ContainsKey(consumerType))
-                return InjectorDictionary[consumerType];
-
-            return CreateInjector(consumerType);
+            return Container.GetInjector(consumerType);
         }
         
         /// <summary>
@@ -119,38 +101,9 @@ namespace UIComponents
         /// <param name="consumerType">Consumer type</param>
         public static void RemoveInjector(Type consumerType)
         {
-            InjectorDictionary.Remove(consumerType);
+            Container.RemoveInjector(consumerType);
         }
-        
-        private static DependencyInjector CreateInjector(Type consumerType)
-        {
-            var injectAttributes = (DependencyAttribute[])
-                consumerType.GetCustomAttributes(typeof(DependencyAttribute), true);
-            
-            var injector = new DependencyInjector(injectAttributes);
 
-            InjectorDictionary.Add(consumerType, injector);
-
-            return injector;
-        }
-        
-        private static object CreateInstance(Type dependencyType)
-        {
-            object instance;
-
-            if (InstantiatedInstanceDictionary.ContainsKey(dependencyType))
-            {
-                instance = InstantiatedInstanceDictionary[dependencyType];
-            }
-            else
-            {
-                instance = Activator.CreateInstance(dependencyType);
-                InstantiatedInstanceDictionary[dependencyType] = instance;
-            }
-
-            return instance;
-        }
-        
         /// <summary>
         /// Constructs a new injector with no dependencies configured.
         /// </summary>
@@ -166,13 +119,16 @@ namespace UIComponents
             foreach (var dependencyAttribute in dependencyAttributes)
             {
                 var dependencyType = dependencyAttribute.DependencyType;
-                var providerType = dependencyAttribute.ProvideType;
-
-                if (DependencyDictionary.ContainsKey(dependencyType))
-                    continue;
                 
-                DependencyDictionary[dependencyType] = CreateInstance(providerType);
-                DefaultDependencyTypeDictionary[dependencyType] = providerType;
+                if (_dependencyDictionary.ContainsKey(dependencyType))
+                    continue;
+
+                var providerType = dependencyAttribute.ProvideType;
+                var scope = dependencyAttribute.Scope;
+
+                var dependency = Container.CreateDependency(dependencyType, providerType, scope);
+
+                _dependencyDictionary.Add(dependencyType, dependency);
             }
         }
 
@@ -180,16 +136,28 @@ namespace UIComponents
         /// Sets the instance used for a dependency.
         /// </summary>
         /// <param name="instance">New instance</param>
+        /// <param name="scope">Dependency scope</param>
         /// <typeparam name="T">Dependency type</typeparam>
         /// <exception cref="ArgumentNullException">
         /// Raised if the argument is null
         /// </exception>
-        public void SetDependency<T>([NotNull] T instance) where T : class
+        public void SetDependency<T>([NotNull] T instance, Scope scope = Scope.Singleton)
+            where T : class
         {
             if (instance == null)
                 throw new ArgumentNullException(nameof(instance));
+
+            var dependencyType = typeof(T);
             
-            DependencyDictionary[typeof(T)] = instance;
+            if (_dependencyDictionary.ContainsKey(dependencyType))
+            {
+                _dependencyDictionary[dependencyType].ChangeInstance(instance);
+                return;
+            }
+            
+            var dependency = Container.CreateDependency(dependencyType, instance, scope);
+            
+            _dependencyDictionary.Add(dependencyType, dependency);
         }
 
         /// <summary>
@@ -198,25 +166,48 @@ namespace UIComponents
         /// <typeparam name="T">Dependency type</typeparam>
         public void ClearDependency<T>() where T : class
         {
-            DependencyDictionary.Remove(typeof(T));
+            var type = typeof(T);
+            
+            if (_dependencyDictionary.ContainsKey(type))
+                _dependencyDictionary[type].Clear();
         }
 
         /// <summary>
-        /// Restores the default dependency, which is the one
-        /// set by <see cref="DependencyAttribute"/>.
+        /// Restores the default dependency. If a singleton instance
+        /// exists, it is restored. Otherwise, a new instance
+        /// of the dependency is created.
         /// </summary>
         /// <typeparam name="T">Dependency type</typeparam>
         /// <exception cref="InvalidOperationException">
-        /// Thrown if no default dependency type exists
+        /// Thrown if no configured dependency exists
         /// </exception>
         public void RestoreDefaultDependency<T>() where T : class
         {
             var dependencyType = typeof(T);
             
-            if (!DefaultDependencyTypeDictionary.TryGetValue(dependencyType, out var providerType))
-                throw new InvalidOperationException($"No default dependency type for {dependencyType}");
+            if (!_dependencyDictionary.ContainsKey(dependencyType))
+                throw new InvalidOperationException($"No dependency configured for {dependencyType}");
 
-            DependencyDictionary[typeof(T)] = CreateInstance(providerType);
+            var dependency = _dependencyDictionary[dependencyType];
+            var initialProviderType = dependency.InitialProviderType;
+            
+            object instance = null;
+
+            if (dependency.Scope == Scope.Singleton)
+                Container.TryGetSingletonInstance(initialProviderType, out instance);
+
+            if (instance == null)
+                instance = Activator.CreateInstance(initialProviderType);
+
+            _dependencyDictionary[dependencyType].ChangeInstance(instance);
+        }
+
+        private bool HasProvider(Type dependencyType)
+        {
+            if (!_dependencyDictionary.ContainsKey(dependencyType))
+                return false;
+
+            return _dependencyDictionary[dependencyType].Instance != null;
         }
 
         /// <summary>
@@ -233,10 +224,10 @@ namespace UIComponents
         {
             var type = typeof(T);
 
-            if (!DependencyDictionary.ContainsKey(type))
+            if (!HasProvider(type))
                 throw new MissingProviderException(type);
             
-            return (T) DependencyDictionary[type];
+            return (T) _dependencyDictionary[type].Instance;
         }
         
         /// <summary>
@@ -251,10 +242,10 @@ namespace UIComponents
         [NotNull]
         public object Provide(Type type)
         {
-            if (!DependencyDictionary.ContainsKey(type))
+            if (!HasProvider(type))
                 throw new MissingProviderException(type);
             
-            return DependencyDictionary[type];
+            return _dependencyDictionary[type].Instance;
         }
         
         /// <summary>
@@ -269,10 +260,10 @@ namespace UIComponents
             instance = null;
             var type = typeof(T);
 
-            if (!DependencyDictionary.ContainsKey(type))
+            if (!HasProvider(type))
                 return false;
 
-            instance = (T) DependencyDictionary[type];
+            instance = (T) _dependencyDictionary[type].Instance;
 
             return true;
         }

--- a/Assets/UIComponents/Core/DependencyInjection/DependencyInjector.cs
+++ b/Assets/UIComponents/Core/DependencyInjection/DependencyInjector.cs
@@ -63,8 +63,9 @@ namespace UIComponents
         }
         
         /// <summary>
-        /// Restores the default dependency, which is the one
-        /// set by <see cref="DependencyAttribute"/>.
+        /// Resets the provided instance of a dependency.
+        /// If a singleton instance exists, it is restored.
+        /// Otherwise, a new instance of the dependency is created.
         /// </summary>
         /// <remarks>
         /// Can be used in unit tests to clear
@@ -73,15 +74,15 @@ namespace UIComponents
         /// <typeparam name="TConsumer">Consumer type</typeparam>
         /// <typeparam name="TDependency">Dependency type</typeparam>
         /// <exception cref="InvalidOperationException">
-        /// Thrown if no default dependency type exists
+        /// Thrown if no configured dependency exists
         /// </exception>
-        public static void RestoreDefaultDependency<TConsumer, TDependency>()
+        public static void ResetProvidedInstance<TConsumer, TDependency>()
             where TConsumer : class
             where TDependency : class
         {
             var injector = GetInjector(typeof(TConsumer));
             
-            injector.RestoreDefaultDependency<TDependency>();
+            injector.ResetProvidedInstance<TDependency>();
         }
 
         /// <summary>
@@ -173,15 +174,15 @@ namespace UIComponents
         }
 
         /// <summary>
-        /// Restores the default dependency. If a singleton instance
-        /// exists, it is restored. Otherwise, a new instance
-        /// of the dependency is created.
+        /// Resets the provided instance of a dependency.
+        /// If a singleton instance exists, it is restored.
+        /// Otherwise, a new instance of the dependency is created.
         /// </summary>
         /// <typeparam name="T">Dependency type</typeparam>
         /// <exception cref="InvalidOperationException">
         /// Thrown if no configured dependency exists
         /// </exception>
-        public void RestoreDefaultDependency<T>() where T : class
+        public void ResetProvidedInstance<T>() where T : class
         {
             var dependencyType = typeof(T);
             

--- a/Assets/UIComponents/Core/DependencyInjection/DiContainer.cs
+++ b/Assets/UIComponents/Core/DependencyInjection/DiContainer.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace UIComponents
+{
+    /// <summary>
+    /// An internal class for storing injectors and singleton instances.
+    /// </summary>
+    internal class DiContainer
+    {
+        /// <summary>
+        /// Contains all injectors created for consumers.
+        /// </summary>
+        internal readonly Dictionary<Type, DependencyInjector> InjectorDictionary;
+        
+        /// <summary>
+        /// Contains the instantiated singleton dependencies which are consumed
+        /// by interested parties.
+        /// </summary>
+        internal readonly Dictionary<Type, object> SingletonInstanceDictionary;
+
+        public DiContainer()
+        {
+            InjectorDictionary =
+                new Dictionary<Type, DependencyInjector>();
+            
+            SingletonInstanceDictionary
+                = new Dictionary<Type, object>();
+        }
+        
+        private DependencyInjector CreateInjector(Type consumerType)
+        {
+            var injectAttributes = (DependencyAttribute[])
+                consumerType.GetCustomAttributes(typeof(DependencyAttribute), true);
+            
+            var injector = new DependencyInjector(injectAttributes);
+
+            InjectorDictionary.Add(consumerType, injector);
+
+            return injector;
+        }
+
+        /// <summary>
+        /// Returns the consumer's dependency injector, creating
+        /// one if it does not exist.
+        /// </summary>
+        /// <param name="consumerType">Consumer type</param>
+        /// <returns>Dependency injector</returns>
+        public DependencyInjector GetInjector(Type consumerType)
+        {
+            if (InjectorDictionary.ContainsKey(consumerType))
+                return InjectorDictionary[consumerType];
+
+            return CreateInjector(consumerType);
+        }
+        
+        /// <summary>
+        /// Removes the consumer's dependency injector.
+        /// </summary>
+        /// <param name="consumerType">Consumer type</param>
+        public void RemoveInjector(Type consumerType)
+        {
+            InjectorDictionary.Remove(consumerType);
+        }
+
+        /// <summary>
+        /// Clears the container.
+        /// </summary>
+        public void Clear()
+        {
+            InjectorDictionary.Clear();
+            SingletonInstanceDictionary.Clear();
+        }
+        
+        /// <summary>
+        /// Attempts to fetch a singleton instance.
+        /// </summary>
+        /// <param name="type">Singleton type</param>
+        /// <param name="instance">Singleton instance</param>
+        /// <returns>Whether the instance could be fetched</returns>
+        public bool TryGetSingletonInstance(Type type, out object instance)
+        {
+            return SingletonInstanceDictionary.TryGetValue(type, out instance);
+        }
+
+        private Dependency CreateSingletonDependency(Type dependencyType, Type providerType)
+        {
+            if (SingletonInstanceDictionary.TryGetValue(providerType, out var instance))
+                return new Dependency(dependencyType, instance, Scope.Singleton);
+
+            var dependency = new Dependency(dependencyType, providerType, Scope.Singleton);
+            
+            SingletonInstanceDictionary.Add(providerType, dependency.Instance);
+            
+            return dependency;
+        }
+        
+        private Dependency CreateTransientDependency(Type dependencyType, Type providerType)
+        {
+            return new Dependency(dependencyType, providerType, Scope.Transient);
+        }
+
+        /// <summary>
+        /// Creates a new Dependency object with the given dependency and provider types.
+        /// </summary>
+        /// <param name="dependencyType">Dependency type</param>
+        /// <param name="providerType">Provider type</param>
+        /// <param name="scope">Dependency scope</param>
+        /// <returns>Dependency object</returns>
+        public Dependency CreateDependency(Type dependencyType, Type providerType, Scope scope)
+        {
+            if (scope == Scope.Singleton)
+                return CreateSingletonDependency(dependencyType, providerType);
+            
+            return CreateTransientDependency(dependencyType, providerType);
+        }
+
+        /// <summary>
+        /// Creates a new Dependency object with the a dependency type and provided instance.
+        /// </summary>
+        /// <param name="dependencyType">Dependency type</param>
+        /// <param name="instance">Provided instance</param>
+        /// <param name="scope">Dependency scope</param>
+        /// <returns>Dependency object</returns>
+        public Dependency CreateDependency(Type dependencyType, object instance, Scope scope)
+        {
+            var instanceType = instance.GetType();
+            
+            if (scope == Scope.Singleton && !SingletonInstanceDictionary.ContainsKey(instanceType))
+                SingletonInstanceDictionary.Add(instanceType, instance);
+            
+            return new Dependency(dependencyType, instance, scope);
+        }
+    }
+}

--- a/Assets/UIComponents/Core/DependencyInjection/DiContainer.cs
+++ b/Assets/UIComponents/Core/DependencyInjection/DiContainer.cs
@@ -18,7 +18,7 @@ namespace UIComponents
         /// by interested parties.
         /// </summary>
         internal readonly Dictionary<Type, object> SingletonInstanceDictionary;
-
+        
         public DiContainer()
         {
             InjectorDictionary =

--- a/Assets/UIComponents/Core/DependencyInjection/DiContainer.cs.meta
+++ b/Assets/UIComponents/Core/DependencyInjection/DiContainer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e4db17fa6924498f994d52d366a536b8
+timeCreated: 1657457626

--- a/Assets/UIComponents/Core/DependencyInjection/Scope.cs
+++ b/Assets/UIComponents/Core/DependencyInjection/Scope.cs
@@ -1,0 +1,19 @@
+﻿namespace UIComponents
+{
+    /// <summary>
+    /// An enum for dependency scopes.
+    /// </summary>
+    public enum Scope
+    {
+        /// <summary>
+        /// A singleton dependency, which is cached. All consumers receive
+        /// the same instance.
+        /// </summary>
+        Singleton,
+        /// <summary>
+        /// A dependency which is not cached. All consumers receive their
+        /// own instance.
+        /// </summary>
+        Transient
+    }
+}

--- a/Assets/UIComponents/Core/DependencyInjection/Scope.cs.meta
+++ b/Assets/UIComponents/Core/DependencyInjection/Scope.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ee35760fc2f44b84bff42ccc6226beb4
+timeCreated: 1657428101

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -17,7 +17,7 @@ PlayerSettings:
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.13725491, g: 0.12156863, b: 0.1254902, a: 1}
-  m_ShowUnitySplashScreen: 1
+  m_ShowUnitySplashScreen: 0
   m_ShowUnitySplashLogo: 1
   m_SplashScreenOverlayOpacity: 1
   m_SplashScreenAnimation: 1
@@ -88,7 +88,7 @@ PlayerSettings:
   bakeCollisionMeshes: 0
   forceSingleInstance: 0
   useFlipModelSwapchain: 1
-  resizableWindow: 0
+  resizableWindow: 1
   useMacAppStoreValidation: 0
   macAppStoreCategory: public.app-category.games
   gpuSkinning: 1
@@ -99,7 +99,7 @@ PlayerSettings:
   xboxEnableFitness: 0
   visibleInBackground: 1
   allowFullscreenSwitch: 1
-  fullscreenMode: 1
+  fullscreenMode: 3
   xboxSpeechDB: 0
   xboxEnableHeadOrientation: 0
   xboxEnableGuest: 0
@@ -163,7 +163,7 @@ PlayerSettings:
   AndroidMinSdkVersion: 19
   AndroidTargetSdkVersion: 0
   AndroidPreferredInstallLocation: 1
-  aotOptions: 
+  aotOptions: nimt-trampolines=1024
   stripEngineCode: 1
   iPhoneStrippingLevel: 0
   iPhoneScriptCallOptimization: 0
@@ -570,7 +570,18 @@ PlayerSettings:
   ps4AllowPS5Detection: 0
   ps4GPU800MHz: 1
   ps4attribEyeToEyeDistanceSettingVR: 0
-  ps4IncludedModules: []
+  ps4IncludedModules:
+  - libc.prx
+  - libSceAudioLatencyEstimation.prx
+  - libSceFace.prx
+  - libSceFaceTracker.prx
+  - libSceFios2.prx
+  - libSceHand.prx
+  - libSceHandTracker.prx
+  - libSceHeadTracker.prx
+  - libSceJobManager.prx
+  - libSceNpToolkit2.prx
+  - libSceS3DConversion.prx
   ps4attribVROutputEnabled: 0
   monoEnv: 
   splashScreenBackgroundSourceLandscape: {fileID: 0}


### PR DESCRIPTION
This PR adds support for transient dependencies, which are not cached.

```csharp
[Dependency(typeof(IAssetResolver), provide: typeof(AddressableAssetResolver), Scope.Transient)]
public class MyComponent : UIComponent {}
```

Now, each instance of `MyComponent` receives its own instance of `AddressableAssetResolver`.