### PR TITLE
fix(ProvideAttribute): fix fields being populated after assets are loaded

### DIFF
--- a/Assets/UIComponents.Benchmarks/BenchmarkUtils.cs
+++ b/Assets/UIComponents.Benchmarks/BenchmarkUtils.cs
@@ -5,7 +5,7 @@ namespace UIComponents.Benchmarks
 {
     public static class BenchmarkUtils
     {
-        public const string Version = "0.20.0.0";
+        public const string Version = "0.21.0.0";
         
         private static SampleGroup[] GetProfilerMarkers()
         {
@@ -13,8 +13,7 @@ namespace UIComponents.Benchmarks
             {
                 new SampleGroup("UIComponent.DependencySetup"),
                 new SampleGroup("UIComponent.CacheSetup"),
-                new SampleGroup("UIComponent.LayoutAndStylesSetup"),
-                new SampleGroup("UIComponent.PopulateFields")
+                new SampleGroup("UIComponent.LayoutAndStylesSetup")
             };
         }
         

--- a/Assets/UIComponents.Tests/ProvideAttributeTests.cs
+++ b/Assets/UIComponents.Tests/ProvideAttributeTests.cs
@@ -1,8 +1,6 @@
-﻿using System.Collections;
-using NSubstitute;
+﻿using NSubstitute;
 using NUnit.Framework;
 using UIComponents.Testing;
-using UnityEngine.TestTools;
 
 namespace UIComponents.Tests
 {
@@ -53,24 +51,18 @@ namespace UIComponents.Tests
                 .Build();
         }
         
-        [UnityTest]
-        public IEnumerator Provides_Dependencies_Automatically()
+        [Test]
+        public void Provides_Dependencies_Automatically()
         {
             var component = _testBed.CreateComponent<ComponentWithDependencies>();
-
-            yield return component.WaitForInitializationEnumerator();
-            
             Assert.That(component.StringProperty, Is.InstanceOf<StringClass>());
             Assert.That(component.FloatProperty, Is.InstanceOf<FloatClass>());
         }
 
-        [UnityTest]
-        public IEnumerator Allows_Providing_Dependencies_With_A_Cast()
+        [Test]
+        public void Allows_Providing_Dependencies_With_A_Cast()
         {
             var component = _testBed.CreateComponent<ComponentWithDependencies>();
-
-            yield return component.WaitForInitializationEnumerator();
-            
             Assert.That(component.FloatClassInstance, Is.InstanceOf<FloatClass>());
         }
         
@@ -84,26 +76,19 @@ namespace UIComponents.Tests
             public readonly StringClass StringClassInstance;
         }
         
-        [UnityTest]
-        public IEnumerator Logs_Error_When_Provider_Is_Missing()
+        [Test]
+        public void Logs_Error_When_Provider_Is_Missing()
         {
             var component = _testBed.CreateComponent<ComponentWithInvalidDependency>();
-            
-            yield return component.WaitForInitializationEnumerator();
-
             Assert.That(component.StringProperty, Is.Null);
             _mockLogger.Received().LogError("Could not provide IStringProperty to StringProperty", component);
         }
 
-        [UnityTest]
-        public IEnumerator Logs_Error_On_Invalid_Cast()
+        [Test]
+        public void Logs_Error_On_Invalid_Cast()
         {
             var component = _testBed.CreateComponent<ComponentWithInvalidDependency>();
-            
-            yield return component.WaitForInitializationEnumerator();
-            
             Assert.That(component.StringClassInstance, Is.Null);
-            
             _mockLogger.Received().LogError("Could not cast IFloatProperty to StringClass", component);
         }
     }

--- a/Assets/UIComponents/Core/ProvideAttribute.cs
+++ b/Assets/UIComponents/Core/ProvideAttribute.cs
@@ -29,6 +29,10 @@ namespace UIComponents
     [MeansImplicitUse]
     public class ProvideAttribute : Attribute
     {
+        /// <summary>
+        /// If set, an instance of the specified type will be provided and
+        /// cast to the field type.
+        /// </summary>
         public Type CastFrom { get; set; }
     }
 }


### PR DESCRIPTION
Currently, fields decorated with `ProvideAttribute` are populated after assets have are loaded. This PR fixes that.