### PR TITLE
feat(UIComponent): InitializationTask property

### DIFF
--- a/Assets/UIComponents.Benchmarks/BenchmarkUtils.cs
+++ b/Assets/UIComponents.Benchmarks/BenchmarkUtils.cs
@@ -5,7 +5,7 @@ namespace UIComponents.Benchmarks
 {
     public static class BenchmarkUtils
     {
-        public const string Version = "0.21.0.0";
+        public const string Version = "0.22.0.0";
         
         private static SampleGroup[] GetProfilerMarkers()
         {
@@ -22,7 +22,7 @@ namespace UIComponents.Benchmarks
             Measure.Method(async () =>
                 {
                     var component = new TComponent();
-                    await component.WaitForInitialization();
+                    await component.InitializationTask;
                 })
                 .SetUp(() =>
                 {
@@ -42,7 +42,7 @@ namespace UIComponents.Benchmarks
             Measure.Method(async () => 
                 {
                     var component = new TComponent();
-                    await component.WaitForInitialization();
+                    await component.InitializationTask;
                 })
                 .SampleGroup(new SampleGroup("Warm Cache Time"))
                 .MeasurementCount(50)

--- a/Assets/UIComponents.Tests/UIComponentTests.cs
+++ b/Assets/UIComponents.Tests/UIComponentTests.cs
@@ -1,8 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using UIComponents.Internal;
 using UIComponents.Testing;
 using UnityEngine;
+using UnityEngine.TestTools;
 using UnityEngine.UIElements;
 
 namespace UIComponents.Tests
@@ -80,6 +83,38 @@ namespace UIComponents.Tests
                 
                 Assert.That(component.InitializationTask.IsCompleted, Is.True);
                 Assert.That(component.InitializationTask.Result, Is.SameAs(component));
+            }
+
+            [UnityTest]
+            public IEnumerator Allows_Waiting_For_Initialization()
+            {
+                var component = _testBed.CreateComponent<TestComponent>();
+                
+                Assert.That(component.Initialized, Is.False);
+
+                _mockAssetResolver.CompleteLoad<VisualTreeAsset>("Layout");
+                _mockAssetResolver.CompleteLoad<StyleSheet>("Stylesheet1");
+                _mockAssetResolver.CompleteLoad<StyleSheet>("Stylesheet2");
+
+                yield return component.WaitForInitializationEnumerator();
+                
+                Assert.That(component.Initialized, Is.True);
+            }
+            
+            [UnityTest]
+            public IEnumerator Allows_Waiting_For_Initialization_With_Obsolete_Method()
+            {
+                var component = _testBed.CreateComponent<TestComponent>();
+                
+                Assert.That(component.Initialized, Is.False);
+                
+                _mockAssetResolver.CompleteLoad<VisualTreeAsset>("Layout");
+                _mockAssetResolver.CompleteLoad<StyleSheet>("Stylesheet1");
+                _mockAssetResolver.CompleteLoad<StyleSheet>("Stylesheet2");
+
+                yield return component.WaitForInitialization().AsEnumerator();
+                
+                Assert.That(component.Initialized, Is.True);
             }
             
             private class BareTestComponent : UIComponent {}

--- a/Assets/UIComponents.Tests/UIComponentTests.cs
+++ b/Assets/UIComponents.Tests/UIComponentTests.cs
@@ -1,6 +1,9 @@
-﻿using System.Collections;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using NUnit.Framework;
-using UnityEngine.TestTools;
+using UIComponents.Testing;
+using UnityEngine;
+using UnityEngine.UIElements;
 
 namespace UIComponents.Tests
 {
@@ -8,19 +11,92 @@ namespace UIComponents.Tests
     public class UIComponentTests
     {
         [TestFixture]
+        public class Initialization
+        {
+            private class MockAssetResolver : IAssetResolver
+            {
+                public readonly Dictionary<string, object> TaskCompletionSources =
+                    new Dictionary<string, object>();
+
+                public Task<T> LoadAsset<T>(string assetPath) where T : Object
+                {
+                    var source = new TaskCompletionSource<T>();
+                    TaskCompletionSources.Add(assetPath, source);
+                    return source.Task;
+                }
+
+                public void CompleteLoad<T>(string assetPath) where T : ScriptableObject
+                {
+                    var source = (TaskCompletionSource<T>) TaskCompletionSources[assetPath];
+                    source.SetResult(ScriptableObject.CreateInstance<T>());
+                }
+
+                public bool AssetExists(string assetPath)
+                {
+                    return true;
+                }
+            }
+
+            [Layout("Layout")]
+            [Stylesheet("Stylesheet1")]
+            [Stylesheet("Stylesheet2")]
+            private class TestComponent : UIComponent {}
+
+            private TestBed _testBed;
+            private MockAssetResolver _mockAssetResolver;
+
+            [SetUp]
+            public void SetUp()
+            {
+                _mockAssetResolver = new MockAssetResolver();
+                _testBed = TestBed.Create()
+                    .WithSingleton<IAssetResolver>(_mockAssetResolver)
+                    .Build();
+            }
+
+            [Test]
+            public void Sets_The_Initialized_Value()
+            {
+                var component = _testBed.CreateComponent<TestComponent>();
+                Assert.That(component.Initialized, Is.False);
+
+                _mockAssetResolver.CompleteLoad<VisualTreeAsset>("Layout");
+                _mockAssetResolver.CompleteLoad<StyleSheet>("Stylesheet1");
+                _mockAssetResolver.CompleteLoad<StyleSheet>("Stylesheet2");
+                
+                Assert.That(component.Initialized, Is.True);
+            }
+
+            [Test]
+            public void Completes_Initialization_Task()
+            {
+                var component = _testBed.CreateComponent<TestComponent>();
+                
+                Assert.That(component.InitializationTask.IsCompleted, Is.False);
+                
+                _mockAssetResolver.CompleteLoad<VisualTreeAsset>("Layout");
+                _mockAssetResolver.CompleteLoad<StyleSheet>("Stylesheet1");
+                _mockAssetResolver.CompleteLoad<StyleSheet>("Stylesheet2");
+                
+                Assert.That(component.InitializationTask.IsCompleted, Is.True);
+                Assert.That(component.InitializationTask.Result, Is.SameAs(component));
+            }
+            
+            private class BareTestComponent : UIComponent {}
+
+            [Test]
+            public void Bare_Component_Initializes_Synchronously()
+            {
+                var component = new BareTestComponent();
+                Assert.That(component.Initialized, Is.True);
+            }
+        }
+        
+        [TestFixture]
         public class GetTypeName
         {
             private class TestComponent : UIComponent {}
 
-            [UnityTest]
-            public IEnumerator It_Is_Initialized()
-            {
-                var component = new TestComponent();
-                Assert.That(component.Initialized, Is.False);
-                yield return component.WaitForInitializationEnumerator();
-                Assert.That(component.Initialized, Is.True);
-            }
-            
             [Test]
             public void ShouldReturnTypeName()
             {

--- a/Assets/UIComponents/Core/UIComponent.cs
+++ b/Assets/UIComponents/Core/UIComponent.cs
@@ -57,6 +57,11 @@ namespace UIComponents
         public bool Initialized { get; private set; }
 
         /// <summary>
+        /// A Task that completes when the UIComponent has been fully initialized.
+        /// </summary>
+        public Task<UIComponent> InitializationTask => _initCompletionSource.Task;
+
+        /// <summary>
         /// The IUIComponentLogger used by this UIComponent.
         /// Defaults to <see cref="UIComponentDebugLogger"/>.
         /// </summary>
@@ -186,7 +191,7 @@ namespace UIComponents
         /// <returns>An enumerator which yields when the component has initialized</returns>
         public IEnumerator WaitForInitializationEnumerator()
         {
-            yield return WaitForInitialization().AsEnumerator();
+            yield return _initCompletionSource.Task.AsEnumerator();
         }
         
         /// <summary>

--- a/Assets/UIComponents/Core/UIComponent.cs
+++ b/Assets/UIComponents/Core/UIComponent.cs
@@ -183,6 +183,7 @@ namespace UIComponents
         }
         
         /// <returns>A Task which resolves when the component has initialized</returns>
+        [Obsolete("Use InitializationTask instead.")]
         public Task<UIComponent> WaitForInitialization()
         {
             return _initCompletionSource.Task;

--- a/Assets/UIComponents/Testing/TestBed.cs
+++ b/Assets/UIComponents/Testing/TestBed.cs
@@ -93,7 +93,7 @@ namespace UIComponents.Testing
         {
             var component = CreateComponent(factoryPredicate);
             
-            var initTask = component.WaitForInitialization();
+            var initTask = component.InitializationTask;
             var timeoutTask = Task.Delay(AsyncTimeout);
 
             var task = await Task.WhenAny(initTask, timeoutTask);

--- a/ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json
+++ b/ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json
@@ -6,7 +6,7 @@
             {
                 "type": "System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                 "key": "IncludeAssemblies",
-                "value": "{\"m_Value\":\"UIComponents,UIComponents.Addressables\"}"
+                "value": "{\"m_Value\":\"UIComponents,UIComponents.Addressables,UIComponents.Testing\"}"
             },
             {
                 "type": "System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",


### PR DESCRIPTION
This PR obsoletes `WaitForInitialization()` in favor of `InitializationTask`.

Also, asset loading is made more stable. Bare components initialize synchronously.