### PR TITLE
Make most classes sealed

### DIFF
--- a/Assets/UIComponents/Core/AssetPathAttribute.cs
+++ b/Assets/UIComponents/Core/AssetPathAttribute.cs
@@ -31,7 +31,7 @@ namespace UIComponents
     /// </example>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     [BaseTypeRequired(typeof(UIComponent))]
-    public class AssetPathAttribute : Attribute
+    public sealed class AssetPathAttribute : Attribute
     {
         public readonly string Path;
         

--- a/Assets/UIComponents/Core/DependencyInjection/Dependency.cs
+++ b/Assets/UIComponents/Core/DependencyInjection/Dependency.cs
@@ -6,7 +6,7 @@ namespace UIComponents.DependencyInjection
     /// <summary>
     /// An internal class for provided dependencies.
     /// </summary>
-    internal class Dependency
+    internal sealed class Dependency
     {
         /// <summary>
         /// The instance of the dependency which is provided to consumers.

--- a/Assets/UIComponents/Core/DependencyInjection/DependencyAttribute.cs
+++ b/Assets/UIComponents/Core/DependencyInjection/DependencyAttribute.cs
@@ -7,7 +7,7 @@ namespace UIComponents
     /// </summary>
     /// <seealso cref="UIComponent"/>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
-    public class DependencyAttribute : Attribute
+    public sealed class DependencyAttribute : Attribute
     {
         public readonly Type DependencyType;
 

--- a/Assets/UIComponents/Core/DependencyInjection/DependencyInjector.cs
+++ b/Assets/UIComponents/Core/DependencyInjection/DependencyInjector.cs
@@ -10,7 +10,7 @@ namespace UIComponents.DependencyInjection
     /// </summary>
     /// <seealso cref="UIComponent"/>
     /// <seealso cref="DependencyAttribute"/>
-    public class DependencyInjector
+    public sealed class DependencyInjector
     {
         private readonly DiContainer _container;
 

--- a/Assets/UIComponents/Core/DependencyInjection/DiContainer.cs
+++ b/Assets/UIComponents/Core/DependencyInjection/DiContainer.cs
@@ -7,7 +7,7 @@ namespace UIComponents.DependencyInjection
     /// <summary>
     /// A class for storing injectors and singleton instances.
     /// </summary>
-    public class DiContainer
+    public sealed class DiContainer
     {
         /// <summary>
         /// Contains all injectors created for consumers.

--- a/Assets/UIComponents/Core/DependencyInjection/DiContext.cs
+++ b/Assets/UIComponents/Core/DependencyInjection/DiContext.cs
@@ -6,7 +6,7 @@ namespace UIComponents.DependencyInjection
     /// <summary>
     /// Dependency injection context for consumers.
     /// </summary>
-    public class DiContext
+    public sealed class DiContext
     {
         /// <summary>
         /// The current dependency injection context.

--- a/Assets/UIComponents/Core/Exceptions/MissingProviderException.cs
+++ b/Assets/UIComponents/Core/Exceptions/MissingProviderException.cs
@@ -5,7 +5,7 @@ namespace UIComponents
     /// <summary>
     /// Thrown when a dependency does not have a provider.
     /// </summary>
-    public class MissingProviderException : Exception
+    public sealed class MissingProviderException : Exception
     {
         /// <summary>
         /// The dependency type.

--- a/Assets/UIComponents/Core/LayoutAttribute.cs
+++ b/Assets/UIComponents/Core/LayoutAttribute.cs
@@ -9,7 +9,7 @@ namespace UIComponents
     /// <seealso cref="AssetPathAttribute"/>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
     [BaseTypeRequired(typeof(UIComponent))]
-    public class LayoutAttribute : PathAttribute
+    public sealed class LayoutAttribute : PathAttribute
     {
         public LayoutAttribute(string path)
         {

--- a/Assets/UIComponents/Core/ProvideAttribute.cs
+++ b/Assets/UIComponents/Core/ProvideAttribute.cs
@@ -27,7 +27,7 @@ namespace UIComponents
     /// <seealso cref="DependencyAttribute"/>
     [AttributeUsage(AttributeTargets.Field)]
     [MeansImplicitUse]
-    public class ProvideAttribute : Attribute
+    public sealed class ProvideAttribute : Attribute
     {
         /// <summary>
         /// If set, an instance of the specified type will be provided and

--- a/Assets/UIComponents/Core/QueryAttribute.cs
+++ b/Assets/UIComponents/Core/QueryAttribute.cs
@@ -29,7 +29,7 @@ namespace UIComponents
     /// </example>
     [AttributeUsage(AttributeTargets.Field, AllowMultiple = true)]
     [MeansImplicitUse]
-    public class QueryAttribute : Attribute
+    public sealed class QueryAttribute : Attribute
     {
         /// <summary>
         /// USS name to query by.

--- a/Assets/UIComponents/Core/RootClassAttribute.cs
+++ b/Assets/UIComponents/Core/RootClassAttribute.cs
@@ -8,7 +8,7 @@ namespace UIComponents
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     [BaseTypeRequired(typeof(UIComponent))]
-    public class RootClassAttribute : UIComponentEffectAttribute
+    public sealed class RootClassAttribute : UIComponentEffectAttribute
     {
         private readonly string _className;
         

--- a/Assets/UIComponents/Core/StylesheetAttribute.cs
+++ b/Assets/UIComponents/Core/StylesheetAttribute.cs
@@ -9,7 +9,7 @@ namespace UIComponents
     /// <seealso cref="AssetPathAttribute"/>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     [BaseTypeRequired(typeof(UIComponent))]
-    public class StylesheetAttribute : PathAttribute
+    public sealed class StylesheetAttribute : PathAttribute
     {
         public StylesheetAttribute(string path)
         {

--- a/Assets/UIComponents/Testing/TestBed.cs
+++ b/Assets/UIComponents/Testing/TestBed.cs
@@ -12,7 +12,7 @@ namespace UIComponents.Testing
     /// <para/>
     /// You can initialize an instance with <see cref="Create"/>.
     /// </summary>
-    public class TestBed
+    public sealed class TestBed
     {
         /// <summary>
         /// Timeout for async operations. Defaults to eight seconds.

--- a/Assets/UIComponents/Testing/TestBedBuilder.cs
+++ b/Assets/UIComponents/Testing/TestBedBuilder.cs
@@ -5,7 +5,7 @@ namespace UIComponents.Testing
     /// <summary>
     /// A class for configuring a <see cref="TestBed"/> instance with dependencies.
     /// </summary>
-    public class TestBedBuilder
+    public sealed class TestBedBuilder
     {
         private readonly TestBed _testBed;
 

--- a/Assets/UIComponents/Testing/TestBedTimeoutException.cs
+++ b/Assets/UIComponents/Testing/TestBedTimeoutException.cs
@@ -5,7 +5,7 @@ namespace UIComponents.Testing
     /// <summary>
     /// Thrown when an asynchronous TestBed operation times out.
     /// </summary>
-    public class TestBedTimeoutException : Exception
+    public sealed class TestBedTimeoutException : Exception
     {
         public override string Message { get; }
         


### PR DESCRIPTION
The following classes are now sealed: AssetPathAttribute, Dependency, DependencyAttribute, DependencyInjector, DiContainer, DiContext, LayoutAttribute, MissingProviderException, ProvideAttribute, QueryAttribute, RootClassAttribute, StylesheetAttribute, TestBed, TestBedBuilder, TestBedTimeoutException.