### PR TITLE
chore(project): upgrade to Unity 2020.3.42f1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  PROJECT_UNITY_VERSION: 2020.3.41f1
+  PROJECT_UNITY_VERSION: 2020.3.42f1
 
 jobs:
   buildAndTestForLinux:
@@ -20,9 +20,9 @@ jobs:
       fail-fast: false
       matrix:
         unityVersion:
-          - 2020.3.41f1
-          - 2021.3.11f1
-          - 2022.1.18f1
+          - 2020.3.42f1
+          - 2021.3.14f1
+          - 2022.1.23f1
             
     steps:
       - uses: actions/checkout@v3
@@ -96,9 +96,9 @@ jobs:
       fail-fast: false
       matrix:
         unityVersion:
-          - 2020.3.41f1
-          - 2021.3.11f1
-          - 2022.1.18f1
+          - 2020.3.42f1
+          - 2021.3.14f1
+          - 2022.1.23f1
 
     steps:
       - uses: actions/checkout@v3

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.3.41f1
-m_EditorVersionWithRevision: 2020.3.41f1 (7c19dc9acfda)
+m_EditorVersion: 2020.3.42f1
+m_EditorVersionWithRevision: 2020.3.42f1 (7ade1201f527)


### PR DESCRIPTION
Upgrades the project to Unity 2020.3.42f1. CI is run on all latest Unity versions.