### PR TITLE
fix(ProvideAttribute): fix NullReferenceException during codegen

### DIFF
--- a/UIComponents.Roslyn/UIComponents.Roslyn.Generation/Generators/DependencyInjection/ProvideAugmentGenerator.cs
+++ b/UIComponents.Roslyn/UIComponents.Roslyn.Generation/Generators/DependencyInjection/ProvideAugmentGenerator.cs
@@ -29,7 +29,7 @@ namespace UIComponents.Roslyn.Generation.Generators.DependencyInjection
                 if (!(member is IFieldSymbol fieldSymbol))
                     continue;
 
-                var memberType = RoslynUtilities.GetMemberType(member) as INamedTypeSymbol;
+                var memberType = fieldSymbol.Type;
 
                 if (memberType == null)
                     continue;
@@ -72,9 +72,13 @@ namespace UIComponents.Roslyn.Generation.Generators.DependencyInjection
         protected override bool ShouldGenerateSource(AugmentGenerationContext context)
         {
             _provideDescriptions.Clear();
+
+            if (_provideAttributeSymbol == null)
+                return false;
+
             GetProvideDescriptions(context, _provideDescriptions);
 
-            return _provideAttributeSymbol != null && _provideDescriptions.Count > 0;
+            return _provideDescriptions.Count > 0;
         }
 
         protected override void BuildUsingStatements(StringBuilder stringBuilder)


### PR DESCRIPTION
A `NullReferenceException` may occur while generating code for `ProvideAttribute` if it is not included into an assembly. This PR fixes that.