### PR TITLE
feat: remove com.unity.roslyn from dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,8 @@ on:
   workflow_dispatch: {}
 
 env:
-  PROJECT_UNITY_VERSION: 2020.3.45f1
+  PROJECT_UNITY_VERSION: 2021.3.19f1
+  UNITY_2020_VERSION: 2020.3.45f1
 
 jobs:
   buildAndTestForLinux:
@@ -22,7 +23,7 @@ jobs:
         unityVersion:
           - 2020.3.45f1
           - 2021.3.19f1
-          - 2022.2.7f1
+          - 2022.2.8f1
         targetPlatform:
           - StandaloneLinux64
           - StandaloneWindows64
@@ -45,6 +46,18 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0.x
+          
+      - name: Set up Node.js
+        if: ${{ matrix.unityVersion == env.UNITY_2020_VERSION }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          
+      - name: Set up Roslyn for Unity 2020
+        if: ${{ matrix.unityVersion == env.UNITY_2020_VERSION }}
+        run: |
+          npm install -g openupm-cli
+          openupm add com.unity.roslyn
             
       - uses: game-ci/unity-test-runner@v2
         id: testRunner
@@ -75,7 +88,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: CodeCoverage/**/*.xml,UIComponents.Roslyn/**/TestResults/**/coverage.cobertura.xml
           
-      - name: Commit upgrade changes
+      - name: Commit Unity project changes
         if: ${{ matrix.unityVersion != env.PROJECT_UNITY_VERSION }}
         run: |
           git config --global user.name 'github-bot'

--- a/Assets/UIComponents/package.json
+++ b/Assets/UIComponents/package.json
@@ -3,10 +3,7 @@
     "displayName": "UIComponents",
     "version": "1.0.0-alpha.6",
     "description": "A small front-end framework for Unity's UIToolkit.",
-    "unity": "2020.3",
-    "dependencies": {
-        "com.unity.roslyn": "0.2.2-preview"
-    },
+    "unity": "2021.3",
     "author": {
         "name": "Joni Savolainen",
         "email": "joni@savolainen.io",

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -4,7 +4,6 @@
     "com.unity.ide.rider": "3.0.18",
     "com.unity.ide.visualstudio": "2.0.17",
     "com.unity.ide.vscode": "1.2.5",
-    "com.unity.roslyn": "0.2.2-preview",
     "com.unity.test-framework": "1.1.33",
     "com.unity.test-framework.performance": "2.8.1-preview",
     "com.unity.testtools.codecoverage": "1.1.1",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -46,22 +46,15 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
-    "com.unity.roslyn": {
-      "version": "0.2.2-preview",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {},
-      "url": "https://packages.unity.com"
-    },
     "com.unity.scriptablebuildpipeline": {
-      "version": "1.19.2",
+      "version": "1.20.1",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.settings-manager": {
-      "version": "1.0.1",
+      "version": "1.0.3",
       "depth": 1,
       "source": "registry",
       "dependencies": {},

--- a/ProjectSettings/MemorySettings.asset
+++ b/ProjectSettings/MemorySettings.asset
@@ -1,0 +1,35 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!387306366 &1
+MemorySettings:
+  m_ObjectHideFlags: 0
+  m_EditorMemorySettings:
+    m_MainAllocatorBlockSize: -1
+    m_ThreadAllocatorBlockSize: -1
+    m_MainGfxBlockSize: -1
+    m_ThreadGfxBlockSize: -1
+    m_CacheBlockSize: -1
+    m_TypetreeBlockSize: -1
+    m_ProfilerBlockSize: -1
+    m_ProfilerEditorBlockSize: -1
+    m_BucketAllocatorGranularity: -1
+    m_BucketAllocatorBucketsCount: -1
+    m_BucketAllocatorBlockSize: -1
+    m_BucketAllocatorBlockCount: -1
+    m_ProfilerBucketAllocatorGranularity: -1
+    m_ProfilerBucketAllocatorBucketsCount: -1
+    m_ProfilerBucketAllocatorBlockSize: -1
+    m_ProfilerBucketAllocatorBlockCount: -1
+    m_TempAllocatorSizeMain: -1
+    m_JobTempAllocatorBlockSize: -1
+    m_BackgroundJobTempAllocatorBlockSize: -1
+    m_JobTempAllocatorReducedBlockSize: -1
+    m_TempAllocatorSizeGIBakingWorker: -1
+    m_TempAllocatorSizeNavMeshWorker: -1
+    m_TempAllocatorSizeAudioWorker: -1
+    m_TempAllocatorSizeCloudWorker: -1
+    m_TempAllocatorSizeGfx: -1
+    m_TempAllocatorSizeJobWorker: -1
+    m_TempAllocatorSizeBackgroundWorker: -1
+    m_TempAllocatorSizePreloadManager: -1
+  m_PlatformMemorySettings: {}

--- a/ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json
+++ b/ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json
@@ -27,6 +27,16 @@
                 "type": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                 "key": "EnableCodeCoverage",
                 "value": "{\"m_Value\":true}"
+            },
+            {
+                "type": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                "key": "GenerateAdditionalReports",
+                "value": "{\"m_Value\":true}"
+            },
+            {
+                "type": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                "key": "OpenReportWhenGenerated",
+                "value": "{\"m_Value\":false}"
             }
         ]
     }

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.3.45f1
-m_EditorVersionWithRevision: 2020.3.45f1 (660cd1701bd5)
+m_EditorVersion: 2021.3.19f1
+m_EditorVersionWithRevision: 2021.3.19f1 (c9714fde33b6)

--- a/ProjectSettings/SceneTemplateSettings.json
+++ b/ProjectSettings/SceneTemplateSettings.json
@@ -1,0 +1,167 @@
+{
+    "templatePinStates": [],
+    "dependencyTypeInfos": [
+        {
+            "userAdded": false,
+            "type": "UnityEngine.AnimationClip",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.Animations.AnimatorController",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.AnimatorOverrideController",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.Audio.AudioMixerController",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.ComputeShader",
+            "ignore": true,
+            "defaultInstantiationMode": 1,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Cubemap",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.GameObject",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.LightingDataAsset",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": false
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.LightingSettings",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Material",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.MonoScript",
+            "ignore": true,
+            "defaultInstantiationMode": 1,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.PhysicMaterial",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.PhysicsMaterial2D",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Rendering.PostProcessing.PostProcessProfile",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Rendering.PostProcessing.PostProcessResources",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Rendering.VolumeProfile",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.SceneAsset",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": false
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Shader",
+            "ignore": true,
+            "defaultInstantiationMode": 1,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.ShaderVariantCollection",
+            "ignore": true,
+            "defaultInstantiationMode": 1,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Texture",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Texture2D",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Timeline.TimelineAsset",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        }
+    ],
+    "defaultDependencyTypeInfo": {
+        "userAdded": false,
+        "type": "<default_scene_template_dependencies>",
+        "ignore": false,
+        "defaultInstantiationMode": 1,
+        "supportsModification": true
+    },
+    "newSceneOverride": 0
+}

--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ of code for you.
 
 ## Requirements
 
-UIComponents requires Unity 2020.3 or newer. Unity's `com.unity.roslyn` package is used to enable
-source generation in Unity 2020.
+UIComponents officially supports Unity 2021.3 or newer. Unity's `com.unity.roslyn` package
+can be used to enable source generation in Unity 2020. Refer to the Installation section
+below for more information.
 
 ## Example usage
 
@@ -191,9 +192,17 @@ Download the latest `.unitypackage` from the [releases](https://github.com/jonis
 
 To update, remove the existing files and extract the new `.unitypackage`.
 
-NOTE: [com.unity.roslyn](https://docs.unity3d.com/Packages/com.unity.roslyn@0.2/manual/index.html) is
-required in Unity 2020. There are two `.unitypackage` archives. The archive with the `_with_roslyn` suffix
-has `com.unity.roslyn` included.
+### For Unity 2020
+
+After installing UIComponents, install the `com.unity.roslyn` package. This enables source generation in Unity 2020.
+
+Add this under `dependencies` in your `Packages/manifest.json` file:
+
+```
+"com.unity.roslyn": "0.2.2-preview"
+```
+
+You may need to restart Unity.
 
 ## Documentation
 

--- a/Scripts/generate_unitypackage.js
+++ b/Scripts/generate_unitypackage.js
@@ -2,8 +2,6 @@
 // generate_unitypackage.js
 //
 // This script creates .unitypackage files in the dist folder.
-// The first file includes UIComponents only and the second
-// has com.unity.roslyn included.
 //
 
 const path = require('path');
@@ -90,9 +88,10 @@ function executeCommand(command) {
 
 executeCommand(command);
 
-fs.mkdirSync(path.join(outputPluginsFolder, 'com.unity.roslyn'));
-fs.cpSync(roslynPackageFolder, path.join(outputPluginsFolder, 'com.unity.roslyn'), { recursive: true });
-
-const secondCommand = createUnityPackerCommand('UIComponents_' + version + '_with_roslyn');;
-
-executeCommand(secondCommand);
+// Uncomment this section to include com.unity.roslyn in the package, if it exists.
+// fs.mkdirSync(path.join(outputPluginsFolder, 'com.unity.roslyn'));
+// s.cpSync(roslynPackageFolder, path.join(outputPluginsFolder, 'com.unity.roslyn'), { recursive: true });
+// 
+// const secondCommand = createUnityPackerCommand('UIComponents_' + version + '_with_roslyn');;
+// 
+// executeCommand(secondCommand);


### PR DESCRIPTION
BREAKING CHANGE: com.unity.roslyn is no longer a dependency. This means that Unity 2020 is no longer officially supported out-of-the-box.