### PR TITLE
Initialize UIComponents on first attach to panel

### DIFF
--- a/Assets/UIComponents.Benchmarks/BenchmarkUtils.cs
+++ b/Assets/UIComponents.Benchmarks/BenchmarkUtils.cs
@@ -20,8 +20,7 @@ namespace UIComponents.Benchmarks
             Measure.Method(async () =>
                 {
                     var component = new TComponent();
-                    component.Initialize();
-                    await component.InitializationTask;
+                    await component.Initialize();
                 })
                 .SetUp(() =>
                 {
@@ -41,8 +40,7 @@ namespace UIComponents.Benchmarks
             Measure.Method(async () => 
                 {
                     var component = new TComponent();
-                    component.Initialize();
-                    await component.InitializationTask;
+                    await component.Initialize();
                 })
                 .SampleGroup(new SampleGroup("Warm Cache Time"))
                 .WarmupCount(10)

--- a/Assets/UIComponents.Benchmarks/BenchmarkUtils.cs
+++ b/Assets/UIComponents.Benchmarks/BenchmarkUtils.cs
@@ -20,6 +20,7 @@ namespace UIComponents.Benchmarks
             Measure.Method(async () =>
                 {
                     var component = new TComponent();
+                    component.Initialize();
                     await component.InitializationTask;
                 })
                 .SetUp(() =>
@@ -40,6 +41,7 @@ namespace UIComponents.Benchmarks
             Measure.Method(async () => 
                 {
                     var component = new TComponent();
+                    component.Initialize();
                     await component.InitializationTask;
                 })
                 .SampleGroup(new SampleGroup("Warm Cache Time"))

--- a/Assets/UIComponents.Benchmarks/BenchmarkUtils.cs
+++ b/Assets/UIComponents.Benchmarks/BenchmarkUtils.cs
@@ -5,7 +5,7 @@ namespace UIComponents.Benchmarks
 {
     public static class BenchmarkUtils
     {
-        public const string Version = "0.29.0.0";
+        public const string Version = "0.30.0.0";
         
         private static SampleGroup[] GetProfilerMarkers()
         {
@@ -14,7 +14,7 @@ namespace UIComponents.Benchmarks
                 new SampleGroup("UIComponent.DependencySetup")
             };
         }
-        
+
         public static void MeasureComponentInitWithColdCache<TComponent>() where TComponent : UIComponent, new()
         {
             Measure.Method(async () =>

--- a/Assets/UIComponents.Tests/LayoutAttributeTests.cs
+++ b/Assets/UIComponents.Tests/LayoutAttributeTests.cs
@@ -44,6 +44,7 @@ namespace UIComponents.Tests
         {
             var testBed = new TestBed<UIComponentWithLayout>().WithSingleton(_mockResolver);
             var component = testBed.CreateComponent();
+            component.Initialize();
             yield return component.WaitForInitializationEnumerator();
             _mockResolver.Received().LoadAsset<VisualTreeAsset>("Assets/MyAsset.uxml");
         }
@@ -53,6 +54,7 @@ namespace UIComponents.Tests
         {
             var testBed = new TestBed<InheritedComponentWithoutAttribute>().WithSingleton(_mockResolver);
             var component = testBed.CreateComponent();
+            component.Initialize();
             yield return component.WaitForInitializationEnumerator();
             _mockResolver.Received().LoadAsset<VisualTreeAsset>("Assets/MyAsset.uxml");
         }
@@ -62,6 +64,7 @@ namespace UIComponents.Tests
         {
             var testBed = new TestBed<InheritedComponentWithAttribute>().WithSingleton(_mockResolver);
             var component = testBed.CreateComponent();
+            component.Initialize();
             yield return component.WaitForInitializationEnumerator();
             _mockResolver.Received().LoadAsset<VisualTreeAsset>("Assets/MyOtherAsset.uxml");
             _mockResolver.DidNotReceive().LoadAsset<VisualTreeAsset>("Assets/MyAsset.uxml");
@@ -71,7 +74,8 @@ namespace UIComponents.Tests
         public void Null_Layout_Is_Handled()
         {
             var testBed = new TestBed<UIComponentWithNullLayout>().WithSingleton(_mockResolver);
-            Assert.DoesNotThrow(() => testBed.CreateComponent());
+            var component = testBed.CreateComponent();
+            Assert.DoesNotThrow(() => component.Initialize());
         }
     }
 }

--- a/Assets/UIComponents.Tests/LayoutAttributeTests.cs
+++ b/Assets/UIComponents.Tests/LayoutAttributeTests.cs
@@ -2,6 +2,7 @@
 using NSubstitute;
 using NSubstitute.ReturnsExtensions;
 using NUnit.Framework;
+using UIComponents.Internal;
 using UIComponents.Testing;
 using UIComponents.Tests.Utilities;
 using UnityEngine.TestTools;
@@ -44,8 +45,7 @@ namespace UIComponents.Tests
         {
             var testBed = new TestBed<UIComponentWithLayout>().WithSingleton(_mockResolver);
             var component = testBed.CreateComponent();
-            component.Initialize();
-            yield return component.WaitForInitializationEnumerator();
+            yield return component.Initialize().AsEnumerator();
             _mockResolver.Received().LoadAsset<VisualTreeAsset>("Assets/MyAsset.uxml");
         }
 
@@ -54,8 +54,7 @@ namespace UIComponents.Tests
         {
             var testBed = new TestBed<InheritedComponentWithoutAttribute>().WithSingleton(_mockResolver);
             var component = testBed.CreateComponent();
-            component.Initialize();
-            yield return component.WaitForInitializationEnumerator();
+            yield return component.Initialize().AsEnumerator();
             _mockResolver.Received().LoadAsset<VisualTreeAsset>("Assets/MyAsset.uxml");
         }
 
@@ -64,18 +63,17 @@ namespace UIComponents.Tests
         {
             var testBed = new TestBed<InheritedComponentWithAttribute>().WithSingleton(_mockResolver);
             var component = testBed.CreateComponent();
-            component.Initialize();
-            yield return component.WaitForInitializationEnumerator();
+            yield return component.Initialize().AsEnumerator();
             _mockResolver.Received().LoadAsset<VisualTreeAsset>("Assets/MyOtherAsset.uxml");
             _mockResolver.DidNotReceive().LoadAsset<VisualTreeAsset>("Assets/MyAsset.uxml");
         }
 
-        [Test]
-        public void Null_Layout_Is_Handled()
+        [UnityTest]
+        public IEnumerator Null_Layout_Is_Handled()
         {
             var testBed = new TestBed<UIComponentWithNullLayout>().WithSingleton(_mockResolver);
             var component = testBed.CreateComponent();
-            Assert.DoesNotThrow(() => component.Initialize());
+            yield return component.Initialize().AsEnumerator();
         }
     }
 }

--- a/Assets/UIComponents.Tests/QueryAttributeTests.cs
+++ b/Assets/UIComponents.Tests/QueryAttributeTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using NSubstitute;
 using NUnit.Framework;
+using UIComponents.Internal;
 using UIComponents.Testing;
 using UnityEngine.TestTools;
 using UnityEngine.UIElements;
@@ -51,10 +52,8 @@ namespace UIComponents.Tests
             var testBed = new TestBed<ComponentWithQueryAttribute>()
                 .WithSingleton(_mockLogger);
             var component = testBed.CreateComponent();
-            component.Initialize();
+            yield return component.Initialize().AsEnumerator();
 
-            yield return component.WaitForInitializationEnumerator();
-            
             Assert.That(component.HelloWorldLabel, Is.InstanceOf<Label>());
             Assert.That(component.HelloWorldLabel.text, Is.EqualTo("Hello world!"));
 
@@ -88,10 +87,8 @@ namespace UIComponents.Tests
             var testBed = new TestBed<ChildComponentWithQueryAttribute>()
                 .WithSingleton(_mockLogger);
             var component = testBed.CreateComponent();
-            component.Initialize();
+            yield return component.Initialize().AsEnumerator();
 
-            yield return component.WaitForInitializationEnumerator();
-            
             Assert.That(component.HelloWorldLabel, Is.InstanceOf<Label>());
             Assert.That(component.TestFoldout, Is.InstanceOf<Foldout>());
             Assert.That(component.FoldoutContent, Is.InstanceOf<Label>());
@@ -117,9 +114,7 @@ namespace UIComponents.Tests
             var testBed = new TestBed<ComponentWithInvalidQueryAttribute>()
                 .WithSingleton(_mockLogger);
             var component = testBed.CreateComponent();
-            component.Initialize();
-            
-            yield return component.WaitForInitializationEnumerator();
+            yield return component.Initialize().AsEnumerator();
 
             Assert.That(component.InvalidField, Is.Null);
             Assert.That(component.InvalidArray, Is.Null);
@@ -144,10 +139,8 @@ namespace UIComponents.Tests
             var testBed = new TestBed<ComponentWithMissingFields>()
                 .WithSingleton(_mockLogger);
             var component = testBed.CreateComponent();
-            component.Initialize();
+            yield return component.Initialize().AsEnumerator();
 
-            yield return component.WaitForInitializationEnumerator();
-            
             Assert.That(component.label, Is.Null);
             Assert.That(component.components.Length, Is.EqualTo(0));
             Assert.That(component.buttons.Count, Is.EqualTo(0));

--- a/Assets/UIComponents.Tests/QueryAttributeTests.cs
+++ b/Assets/UIComponents.Tests/QueryAttributeTests.cs
@@ -51,6 +51,7 @@ namespace UIComponents.Tests
             var testBed = new TestBed<ComponentWithQueryAttribute>()
                 .WithSingleton(_mockLogger);
             var component = testBed.CreateComponent();
+            component.Initialize();
 
             yield return component.WaitForInitializationEnumerator();
             
@@ -87,6 +88,7 @@ namespace UIComponents.Tests
             var testBed = new TestBed<ChildComponentWithQueryAttribute>()
                 .WithSingleton(_mockLogger);
             var component = testBed.CreateComponent();
+            component.Initialize();
 
             yield return component.WaitForInitializationEnumerator();
             
@@ -115,6 +117,7 @@ namespace UIComponents.Tests
             var testBed = new TestBed<ComponentWithInvalidQueryAttribute>()
                 .WithSingleton(_mockLogger);
             var component = testBed.CreateComponent();
+            component.Initialize();
             
             yield return component.WaitForInitializationEnumerator();
 
@@ -141,6 +144,7 @@ namespace UIComponents.Tests
             var testBed = new TestBed<ComponentWithMissingFields>()
                 .WithSingleton(_mockLogger);
             var component = testBed.CreateComponent();
+            component.Initialize();
 
             yield return component.WaitForInitializationEnumerator();
             

--- a/Assets/UIComponents.Tests/QueryClassAttributeTests.cs
+++ b/Assets/UIComponents.Tests/QueryClassAttributeTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using NSubstitute;
 using NUnit.Framework;
+using UIComponents.Internal;
 using UIComponents.Testing;
 using UnityEngine.TestTools;
 using UnityEngine.UIElements;
@@ -70,8 +71,7 @@ namespace UIComponents.Tests
             var testBed = new TestBed<QueryClassTestComponent>()
                 .WithSingleton(_mockLogger);
             _queryClassTestComponent = testBed.CreateComponent();
-            _queryClassTestComponent.Initialize();
-            yield return _queryClassTestComponent.WaitForInitializationEnumerator();
+            yield return _queryClassTestComponent.Initialize().AsEnumerator();
         }
 
         [Test]

--- a/Assets/UIComponents.Tests/QueryClassAttributeTests.cs
+++ b/Assets/UIComponents.Tests/QueryClassAttributeTests.cs
@@ -70,6 +70,7 @@ namespace UIComponents.Tests
             var testBed = new TestBed<QueryClassTestComponent>()
                 .WithSingleton(_mockLogger);
             _queryClassTestComponent = testBed.CreateComponent();
+            _queryClassTestComponent.Initialize();
             yield return _queryClassTestComponent.WaitForInitializationEnumerator();
         }
 

--- a/Assets/UIComponents.Tests/RootClassAttributeTests.cs
+++ b/Assets/UIComponents.Tests/RootClassAttributeTests.cs
@@ -14,6 +14,7 @@ namespace UIComponents.Tests
         public IEnumerator Adds_Class_To_Component()
         {
             var component = new ComponentWithRootClass();
+            component.Initialize();
             yield return component.WaitForInitializationEnumerator();
             
             Assert.That(component.ClassListContains("test-class"), Is.True);
@@ -27,6 +28,7 @@ namespace UIComponents.Tests
         public IEnumerator Adds_Class_To_Component_And_Child_Component()
         {
             var component = new ChildComponentWithRootClass();
+            component.Initialize();
             yield return component.WaitForInitializationEnumerator();
             
             Assert.That(component.ClassListContains("test-class"), Is.True);

--- a/Assets/UIComponents.Tests/RootClassAttributeTests.cs
+++ b/Assets/UIComponents.Tests/RootClassAttributeTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using NUnit.Framework;
+using UIComponents.Internal;
 using UnityEngine.TestTools;
 
 namespace UIComponents.Tests
@@ -14,9 +15,8 @@ namespace UIComponents.Tests
         public IEnumerator Adds_Class_To_Component()
         {
             var component = new ComponentWithRootClass();
-            component.Initialize();
-            yield return component.WaitForInitializationEnumerator();
-            
+            yield return component.Initialize().AsEnumerator();
+
             Assert.That(component.ClassListContains("test-class"), Is.True);
         }
         
@@ -28,9 +28,8 @@ namespace UIComponents.Tests
         public IEnumerator Adds_Class_To_Component_And_Child_Component()
         {
             var component = new ChildComponentWithRootClass();
-            component.Initialize();
-            yield return component.WaitForInitializationEnumerator();
-            
+            yield return component.Initialize().AsEnumerator();
+
             Assert.That(component.ClassListContains("test-class"), Is.True);
             Assert.That(component.ClassListContains("other-test-class"), Is.True);
             Assert.That(component.ClassListContains("final-test-class"), Is.True);

--- a/Assets/UIComponents.Tests/StylesheetAttributeTests.cs
+++ b/Assets/UIComponents.Tests/StylesheetAttributeTests.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using NSubstitute;
 using NUnit.Framework;
+using UIComponents.Internal;
 using UIComponents.Testing;
 using UIComponents.Tests.Utilities;
 using UnityEngine;
@@ -43,10 +44,8 @@ namespace UIComponents.Tests
                 .WithSingleton(_mockLogger)
                 .WithTransient(_mockResolver);
             var component = testBed.CreateComponent();
-            component.Initialize();
-            
-            yield return component.WaitForInitializationEnumerator();
-            
+            yield return component.Initialize().AsEnumerator();
+
             _mockResolver.Received().LoadAsset<StyleSheet>("Assets/StylesheetOne.uss");
             _mockResolver.Received().LoadAsset<StyleSheet>("Assets/StylesheetTwo.uss");
             Assert.That(component.styleSheets.count, Is.EqualTo(2));
@@ -59,9 +58,7 @@ namespace UIComponents.Tests
                 .WithSingleton(_mockLogger)
                 .WithTransient(_mockResolver);
             var component = testBed.CreateComponent();
-            component.Initialize();
-            
-            yield return component.WaitForInitializationEnumerator();
+            yield return component.Initialize().AsEnumerator();
 
             _mockResolver.Received().LoadAsset<StyleSheet>("Assets/StylesheetOne.uss");
             _mockResolver.Received().LoadAsset<StyleSheet>("Assets/StylesheetTwo.uss");
@@ -80,9 +77,7 @@ namespace UIComponents.Tests
                 .WithTransient(_mockResolver);
 
             var component = testBed.CreateComponent();
-            component.Initialize();
-
-            yield return component.WaitForInitializationEnumerator();
+            yield return component.Initialize().AsEnumerator();
 
             _mockResolver.Received().LoadAsset<StyleSheet>("Assets/StylesheetOne.uss");
             _mockLogger.Received().LogError("Could not find stylesheet Assets/StylesheetOne.uss", component);

--- a/Assets/UIComponents.Tests/StylesheetAttributeTests.cs
+++ b/Assets/UIComponents.Tests/StylesheetAttributeTests.cs
@@ -43,6 +43,7 @@ namespace UIComponents.Tests
                 .WithSingleton(_mockLogger)
                 .WithTransient(_mockResolver);
             var component = testBed.CreateComponent();
+            component.Initialize();
             
             yield return component.WaitForInitializationEnumerator();
             
@@ -58,6 +59,7 @@ namespace UIComponents.Tests
                 .WithSingleton(_mockLogger)
                 .WithTransient(_mockResolver);
             var component = testBed.CreateComponent();
+            component.Initialize();
             
             yield return component.WaitForInitializationEnumerator();
 
@@ -78,6 +80,7 @@ namespace UIComponents.Tests
                 .WithTransient(_mockResolver);
 
             var component = testBed.CreateComponent();
+            component.Initialize();
 
             yield return component.WaitForInitializationEnumerator();
 

--- a/Assets/UIComponents.Tests/UIComponentEffectAttributeTests.cs
+++ b/Assets/UIComponents.Tests/UIComponentEffectAttributeTests.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using NUnit.Framework;
+using UIComponents.Internal;
 using UnityEngine.TestTools;
 
 namespace UIComponents.Tests
@@ -38,9 +39,7 @@ namespace UIComponents.Tests
         public IEnumerator Effects_Are_Sorted_By_Priority()
         {
             var component = new UIComponentWithEffects();
-            component.Initialize();
-
-            yield return component.WaitForInitializationEnumerator();
+            yield return component.Initialize().AsEnumerator();
 
             Assert.That(component.AppliedEffects.Count, Is.EqualTo(4));
             Assert.That(component.AppliedEffects[0], Is.EqualTo(999));

--- a/Assets/UIComponents.Tests/UIComponentEffectAttributeTests.cs
+++ b/Assets/UIComponents.Tests/UIComponentEffectAttributeTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using NUnit.Framework;
+using UnityEngine.TestTools;
 
 namespace UIComponents.Tests
 {
@@ -32,10 +34,13 @@ namespace UIComponents.Tests
             public readonly List<int> AppliedEffects = new List<int>();
         }
 
-        [Test]
-        public void Effects_Are_Sorted_By_Priority()
+        [UnityTest]
+        public IEnumerator Effects_Are_Sorted_By_Priority()
         {
             var component = new UIComponentWithEffects();
+            component.Initialize();
+
+            yield return component.WaitForInitializationEnumerator();
 
             Assert.That(component.AppliedEffects.Count, Is.EqualTo(4));
             Assert.That(component.AppliedEffects[0], Is.EqualTo(999));

--- a/Assets/UIComponents.Tests/UIComponentNoAttributesTests.cs
+++ b/Assets/UIComponents.Tests/UIComponentNoAttributesTests.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using NSubstitute;
 using NUnit.Framework;
+using UIComponents.Internal;
 using UIComponents.Testing;
 using UnityEngine.TestTools;
 using UnityEngine.UIElements;
@@ -27,8 +28,7 @@ namespace UIComponents.Tests
             var testBed = new TestBed<UIComponentNoAttributes>()
                 .WithSingleton(_mockResolver);
             _component = testBed.CreateComponent();
-            _component.Initialize();
-            yield return _component.WaitForInitializationEnumerator();
+            yield return _component.Initialize().AsEnumerator();
         }
 
         [TearDown]

--- a/Assets/UIComponents.Tests/UIComponentNoAttributesTests.cs
+++ b/Assets/UIComponents.Tests/UIComponentNoAttributesTests.cs
@@ -27,6 +27,7 @@ namespace UIComponents.Tests
             var testBed = new TestBed<UIComponentNoAttributes>()
                 .WithSingleton(_mockResolver);
             _component = testBed.CreateComponent();
+            _component.Initialize();
             yield return _component.WaitForInitializationEnumerator();
         }
 

--- a/Assets/UIComponents.Tests/UIComponentTests.cs
+++ b/Assets/UIComponents.Tests/UIComponentTests.cs
@@ -6,6 +6,7 @@ using UIComponents.Testing;
 using UnityEngine;
 using UnityEngine.TestTools;
 using UnityEngine.UIElements;
+#pragma warning disable CS4014
 
 namespace UIComponents.Tests
 {

--- a/Assets/UIComponents.Tests/UIComponents.Tests.asmdef
+++ b/Assets/UIComponents.Tests/UIComponents.Tests.asmdef
@@ -15,6 +15,7 @@
         "nunit.framework.dll",
         "NSubstitute.dll",
         "Castle.Core.dll",
+        "System.Threading.Tasks.Extensions.dll",
         "System.Runtime.CompilerServices.Unsafe.dll"
     ],
     "autoReferenced": false,

--- a/Assets/UIComponents.Tests/UIComponents.Tests.asmdef
+++ b/Assets/UIComponents.Tests/UIComponents.Tests.asmdef
@@ -15,7 +15,6 @@
         "nunit.framework.dll",
         "NSubstitute.dll",
         "Castle.Core.dll",
-        "System.Threading.Tasks.Extensions.dll",
         "System.Runtime.CompilerServices.Unsafe.dll"
     ],
     "autoReferenced": false,

--- a/Assets/UIComponents/Core/Internal/TaskExtensions.cs
+++ b/Assets/UIComponents/Core/Internal/TaskExtensions.cs
@@ -11,14 +11,10 @@ namespace UIComponents.Internal
         public static IEnumerator AsEnumerator(this Task task)
         {
             while (!task.IsCompleted)
-            {
                 yield return null;
-            }
 
             if (task.IsFaulted)
-            {
                 ExceptionDispatchInfo.Capture(task.Exception!).Throw();
-            }
 
             yield return null;
         }

--- a/Assets/UIComponents/Core/Internal/TaskExtensions.cs
+++ b/Assets/UIComponents/Core/Internal/TaskExtensions.cs
@@ -17,7 +17,7 @@ namespace UIComponents.Internal
 
             if (task.IsFaulted)
             {
-                ExceptionDispatchInfo.Capture(task.Exception).Throw();
+                ExceptionDispatchInfo.Capture(task.Exception!).Throw();
             }
 
             yield return null;

--- a/Assets/UIComponents/Core/UIComponent.cs
+++ b/Assets/UIComponents/Core/UIComponent.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using UIComponents.DependencyInjection;
 using UIComponents.Internal;
@@ -80,13 +81,24 @@ namespace UIComponents
             UIC_UnregisterEventCallbacks();
         }
 
+        [ExcludeFromCodeCoverage] // Pragmas are shown as uncovered lines
         private void OnFirstAttachToPanel(AttachToPanelEvent evt)
         {
+#pragma warning disable CS4014
             Initialize();
+#pragma warning restore CS4014
             UnregisterCallback<AttachToPanelEvent>(OnFirstAttachToPanel);
         }
 
-        public async void Initialize()
+        /// <summary>
+        /// Starts the initialization of the UIComponent. Does nothing if the UIComponent has already been initialized
+        /// or if initialization is already ongoing.
+        /// </summary>
+        /// <remarks>
+        /// This method is called automatically when the UIComponent is first attached to a panel.
+        /// It can also be called manually to force initialization.
+        /// </remarks>
+        public async Task Initialize()
         {
             if (Initialized || _initializationOngoing)
                 return;

--- a/Assets/UIComponents/Core/UIComponent.cs
+++ b/Assets/UIComponents/Core/UIComponent.cs
@@ -184,9 +184,12 @@ namespace UIComponents
             return _dependencyInjector.TryProvide(out instance);
         }
         
+        private static readonly Task<VisualTreeAsset> NullLayoutTask =
+            Task.FromResult<VisualTreeAsset>(null);
+
         protected virtual Task<VisualTreeAsset> UIC_StartLayoutLoad()
         {
-            return Task.FromResult<VisualTreeAsset>(null);
+            return NullLayoutTask;
         }
 
         protected readonly struct StyleSheetLoadTuple

--- a/Assets/UIComponents/Testing/TestBed.cs
+++ b/Assets/UIComponents/Testing/TestBed.cs
@@ -71,6 +71,7 @@ namespace UIComponents.Testing
         public async Task<TComponent> CreateComponentAsync(Func<TComponent> factoryPredicate)
         {
             var component = CreateComponent(factoryPredicate);
+            component.Initialize();
 
             var initTask = component.InitializationTask;
             var timeoutTask = Task.Delay(AsyncTimeout);

--- a/Assets/UIComponents/Testing/TestBed.cs
+++ b/Assets/UIComponents/Testing/TestBed.cs
@@ -71,9 +71,8 @@ namespace UIComponents.Testing
         public async Task<TComponent> CreateComponentAsync(Func<TComponent> factoryPredicate)
         {
             var component = CreateComponent(factoryPredicate);
-            component.Initialize();
 
-            var initTask = component.InitializationTask;
+            var initTask = component.Initialize();
             var timeoutTask = Task.Delay(AsyncTimeout);
 
             var task = await Task.WhenAny(initTask, timeoutTask);
@@ -81,9 +80,7 @@ namespace UIComponents.Testing
             if (task == timeoutTask)
                 throw new TestBedTimeoutException(component.GetType().Name, (int)AsyncTimeout.TotalMilliseconds);
 
-            var initializedComponent = await initTask;
-
-            return initializedComponent as TComponent;
+            return component;
         }
 
 


### PR DESCRIPTION
Currently, UIComponents start their initialization automatically in the inherited constructor. This has two drawbacks:

1. It is awkward to test.
2. If initialization is synchronous, the OnInit callback is called before superclass constructors.

Now, initialization is started after the component is attached to a panel for the first time. Alternatively, it can be started manually with the Initialize method.