### PR TITLE
chore(project): upgrade to Unity 2021.3.26f1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ on:
   workflow_dispatch: {}
 
 env:
-  PROJECT_UNITY_VERSION: 2021.3.24f1
-  UNITY_2020_VERSION: 2020.3.47f1
+  PROJECT_UNITY_VERSION: 2021.3.26f1
+  UNITY_2020_VERSION: 2020.3.48f1
 
 jobs:
   buildAndTestForLinux:
@@ -21,9 +21,9 @@ jobs:
       fail-fast: false
       matrix:
         unityVersion:
-          - 2020.3.47f1
-          - 2021.3.24f1
-          - 2022.2.17f1
+          - 2020.3.48f1
+          - 2021.3.26f1
+          - 2022.3.0f1
         targetPlatform:
           - StandaloneLinux64
           - StandaloneWindows64

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,12 +1,12 @@
 {
   "dependencies": {
     "com.unity.addressables": "1.18.19",
-    "com.unity.ide.rider": "3.0.21",
+    "com.unity.ide.rider": "3.0.22",
     "com.unity.ide.visualstudio": "2.0.18",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.test-framework": "1.1.33",
     "com.unity.test-framework.performance": "3.0.0-pre.2",
-    "com.unity.testtools.codecoverage": "1.1.1",
+    "com.unity.testtools.codecoverage": "1.2.4",
     "com.unity.ugui": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",
     "com.unity.modules.animation": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -22,7 +22,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.21",
+      "version": "3.0.22",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -82,7 +82,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.testtools.codecoverage": {
-      "version": "1.1.1",
+      "version": "1.2.4",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2021.3.24f1
-m_EditorVersionWithRevision: 2021.3.24f1 (cf10dcf7010d)
+m_EditorVersion: 2021.3.26f1
+m_EditorVersionWithRevision: 2021.3.26f1 (a16dc32e0ff2)


### PR DESCRIPTION
Upgrades the project to latest Unity 2021. CI is run with 2022 LTS (2022.3.0) and the last 2020 LTS version.