### PR TITLE
fix: disable auto reference in predefined assemblies

### DIFF
--- a/Assets/Samples/Addressables/Editor/UIComponents.Samples.Addressables.Editor.asmdef
+++ b/Assets/Samples/Addressables/Editor/UIComponents.Samples.Addressables.Editor.asmdef
@@ -14,7 +14,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [
         "UICOMPONENTS_ADDRESSABLES_INSTALLED"
     ],

--- a/Assets/Samples/Addressables/UIComponents.Samples.Addressables.asmdef
+++ b/Assets/Samples/Addressables/UIComponents.Samples.Addressables.asmdef
@@ -12,7 +12,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [
         "UICOMPONENTS_ADDRESSABLES_INSTALLED"
     ],

--- a/Assets/Samples/Counter/Editor/UIComponents.Samples.Counter.Editor.asmdef
+++ b/Assets/Samples/Counter/Editor/UIComponents.Samples.Counter.Editor.asmdef
@@ -12,7 +12,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Assets/Samples/Counter/UIComponents.Samples.Counter.asmdef
+++ b/Assets/Samples/Counter/UIComponents.Samples.Counter.asmdef
@@ -9,7 +9,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Assets/Samples/EventInterfaces/Editor/UIComponents.Samples.EventInterfaces.Editor.asmdef
+++ b/Assets/Samples/EventInterfaces/Editor/UIComponents.Samples.EventInterfaces.Editor.asmdef
@@ -12,7 +12,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Assets/Samples/EventInterfaces/UIComponents.Samples.EventInterfaces.asmdef
+++ b/Assets/Samples/EventInterfaces/UIComponents.Samples.EventInterfaces.asmdef
@@ -9,7 +9,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Assets/Samples/Query/Editor/UIComponents.Samples.Query.Editor.asmdef
+++ b/Assets/Samples/Query/Editor/UIComponents.Samples.Query.Editor.asmdef
@@ -12,7 +12,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Assets/Samples/Query/UIComponents.Samples.Query.asmdef
+++ b/Assets/Samples/Query/UIComponents.Samples.Query.asmdef
@@ -9,7 +9,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Assets/Samples/Resources/Editor/UIComponents.Samples.Resources.Editor.asmdef
+++ b/Assets/Samples/Resources/Editor/UIComponents.Samples.Resources.Editor.asmdef
@@ -12,7 +12,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Assets/Samples/Resources/UIComponents.Samples.Resources.asmdef
+++ b/Assets/Samples/Resources/UIComponents.Samples.Resources.asmdef
@@ -9,7 +9,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Assets/Samples/UxmlTraits/Editor/UIComponents.Samples.UxmlTraits.Editor.asmdef
+++ b/Assets/Samples/UxmlTraits/Editor/UIComponents.Samples.UxmlTraits.Editor.asmdef
@@ -11,7 +11,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Assets/Samples/UxmlTraits/UIComponents.Samples.UxmlTraits.asmdef
+++ b/Assets/Samples/UxmlTraits/UIComponents.Samples.UxmlTraits.asmdef
@@ -9,7 +9,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Assets/UIComponents.Tests/NSubstitute/castle.core.4.4.1/Castle.Core.dll.meta
+++ b/Assets/UIComponents.Tests/NSubstitute/castle.core.4.4.1/Castle.Core.dll.meta
@@ -8,9 +8,19 @@ PluginImporter:
   defineConstraints: []
   isPreloaded: 0
   isOverridable: 1
-  isExplicitlyReferenced: 0
+  isExplicitlyReferenced: 1
   validateReferences: 1
   platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 0
+        Exclude Linux64: 0
+        Exclude OSXUniversal: 0
+        Exclude Win: 0
+        Exclude Win64: 0
   - first:
       Any: 
     second:
@@ -19,9 +29,35 @@ PluginImporter:
   - first:
       Editor: Editor
     second:
-      enabled: 0
+      enabled: 1
       settings:
+        CPU: AnyCPU
         DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 1
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win
+    second:
+      enabled: 1
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
   - first:
       Windows Store Apps: WindowsStoreApps
     second:

--- a/Assets/UIComponents.Tests/NSubstitute/nsubstitute.4.3.0/NSubstitute.dll.meta
+++ b/Assets/UIComponents.Tests/NSubstitute/nsubstitute.4.3.0/NSubstitute.dll.meta
@@ -9,7 +9,7 @@ PluginImporter:
   - UNITY_INCLUDE_TESTS
   isPreloaded: 0
   isOverridable: 1
-  isExplicitlyReferenced: 0
+  isExplicitlyReferenced: 1
   validateReferences: 0
   platformData:
   - first:

--- a/Assets/UIComponents.Tests/NSubstitute/system.runtime.compilerservices.unsafe.6.0.0/System.Runtime.CompilerServices.Unsafe.dll.meta
+++ b/Assets/UIComponents.Tests/NSubstitute/system.runtime.compilerservices.unsafe.6.0.0/System.Runtime.CompilerServices.Unsafe.dll.meta
@@ -9,7 +9,7 @@ PluginImporter:
   - UNITY_INCLUDE_TESTS
   isPreloaded: 0
   isOverridable: 1
-  isExplicitlyReferenced: 0
+  isExplicitlyReferenced: 1
   validateReferences: 1
   platformData:
   - first:

--- a/Assets/UIComponents.Tests/NSubstitute/system.threading.tasks.extensions.4.5.4/System.Threading.Tasks.Extensions.dll.meta
+++ b/Assets/UIComponents.Tests/NSubstitute/system.threading.tasks.extensions.4.5.4/System.Threading.Tasks.Extensions.dll.meta
@@ -9,7 +9,7 @@ PluginImporter:
   - UNITY_INCLUDE_TESTS
   isPreloaded: 0
   isOverridable: 1
-  isExplicitlyReferenced: 0
+  isExplicitlyReferenced: 1
   validateReferences: 0
   platformData:
   - first:

--- a/Assets/UIComponents/Addressables/UIComponents.Addressables.asmdef
+++ b/Assets/UIComponents/Addressables/UIComponents.Addressables.asmdef
@@ -11,7 +11,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [
         "UICOMPONENTS_ADDRESSABLES_INSTALLED"
     ],

--- a/Assets/UIComponents/Core/UIComponents.asmdef
+++ b/Assets/UIComponents/Core/UIComponents.asmdef
@@ -7,7 +7,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Assets/UIComponents/Editor/UIComponents.Editor.asmdef
+++ b/Assets/UIComponents/Editor/UIComponents.Editor.asmdef
@@ -11,7 +11,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Assets/UIComponents/Testing/UIComponents.Testing.asmdef
+++ b/Assets/UIComponents/Testing/UIComponents.Testing.asmdef
@@ -9,7 +9,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false


### PR DESCRIPTION
BREAKING CHANGE: UIComponents' assemblies are no longer referenced automatically in predefined assemblies.